### PR TITLE
Add concurrency control to issues-from-pr workflow

### DIFF
--- a/.github/workflows/issues-from-pr.yml
+++ b/.github/workflows/issues-from-pr.yml
@@ -6,6 +6,9 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+concurrency:
+  group: issues-from-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 jobs:
   create_issues_from_pr:
     if: contains(join(github.event.pull_request.labels.*.name, ','), 'create-issues')


### PR DESCRIPTION
## Summary
- add concurrency group to the issues-from-pr workflow to avoid duplicate runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce9abda1888324ab21867709e7d810