### PR TITLE
feat: align quiz response types with schema

### DIFF
--- a/web/src/features/quiz/api/types.ts
+++ b/web/src/features/quiz/api/types.ts
@@ -4,20 +4,39 @@ export type ID = string;
 export interface Choice { id: ID; label: string; }
 
 export interface RevealLink {
-  provider: 'youtube' | 'applemusic' | 'spotify' | 'other';
+  provider: 'youtube' | 'appleMusic' | 'spotify' | 'other';
   url: string;
+  label?: string;
 }
 
+export interface RevealMeta {
+  workTitle?: string;
+  trackTitle?: string;
+  composer?: string;
+}
 
-export interface RevealMeta { workTitle?: string; trackTitle?: string; composer?: string; }
-export interface Reveal { links: RevealLink[]; questionId?: ID; choiceId?: ID; correct?: boolean; correctChoiceId?: ID;   meta?: RevealMeta;
+export interface Reveal {
+  links?: RevealLink[];
+  questionId?: ID;
+  choiceId?: ID;
+  correct?: boolean;
+  correctChoiceId?: ID;
+  meta?: RevealMeta;
+}
+
+export interface Artwork {
+  url: string;
+  width: number;
+  height: number;
+  alt?: string;
 }
 
 export interface Question {
   id: ID;
   prompt: string;
   choices: Choice[];
-  reveal: Reveal;
+  reveal?: Reveal;
+  artwork?: Artwork;
 }
 
 export interface Progress { index: number; total: number; }
@@ -30,7 +49,8 @@ export interface RoundMeta {
 export interface RoundsStartResponse {
   round: RoundMeta;
   finished: boolean;
-  question: Question;  reveal?: Reveal;
+  question: Question;
+  reveal?: Reveal;
 }
 
 export interface RoundsNextResponse {


### PR DESCRIPTION
## Summary
- extend quiz API types to cover artwork metadata and the full reveal payload allowed by docs/api/schemas
- normalise provider strings and optional fields so Question/Reveal structures match current mock data and schema expectations
- tidy Playwright metrics tests to compile under stricter type checking by reusing an InstrumentedWindow helper

## Testing
- npm run typecheck