### PR TITLE
fix: correct axe-core oklab color filter logic

### DIFF
--- a/web/tests/e2e/accessibility.spec.ts
+++ b/web/tests/e2e/accessibility.spec.ts
@@ -33,9 +33,14 @@ test.describe('Accessibility smoke', () => {
 
     // Filter out known incomplete results due to Tailwind v4 oklab color format
     // axe-core v4.10 cannot parse oklab() colors yet
-    const unexpectedIncomplete = results.incomplete.filter(
-      (issue) => !(issue.id === 'color-contrast' && (issue as { message?: string }).message?.includes('Unable to parse color "oklab'))
-    );
+    const unexpectedIncomplete = results.incomplete.filter((issue) => {
+      if (issue.id !== 'color-contrast') return true;
+      // Check if any node contains the oklab parsing error message
+      const hasOklabError = issue.nodes?.some((node) =>
+        node.any?.some((check) => check.message?.includes('Unable to parse color "oklab'))
+      );
+      return !hasOklabError;
+    });
     expect.soft(unexpectedIncomplete, 'axe should finish scanning').toHaveLength(0);
     expect(results.violations, `Found accessibility issues on /play: ${JSON.stringify(results.violations, null, 2)}`).toHaveLength(0);
   });
@@ -62,9 +67,14 @@ test.describe('Accessibility smoke', () => {
 
     // Filter out known incomplete results due to Tailwind v4 oklab color format
     // axe-core v4.10 cannot parse oklab() colors yet
-    const unexpectedIncomplete = results.incomplete.filter(
-      (issue) => !(issue.id === 'color-contrast' && (issue as { message?: string }).message?.includes('Unable to parse color "oklab'))
-    );
+    const unexpectedIncomplete = results.incomplete.filter((issue) => {
+      if (issue.id !== 'color-contrast') return true;
+      // Check if any node contains the oklab parsing error message
+      const hasOklabError = issue.nodes?.some((node) =>
+        node.any?.some((check) => check.message?.includes('Unable to parse color "oklab'))
+      );
+      return !hasOklabError;
+    });
     expect.soft(unexpectedIncomplete, 'axe should finish scanning').toHaveLength(0);
     expect(results.violations, `Found accessibility issues on /result: ${JSON.stringify(results.violations, null, 2)}`).toHaveLength(0);
   });

--- a/web/tests/e2e/accessibility.spec.ts
+++ b/web/tests/e2e/accessibility.spec.ts
@@ -35,11 +35,11 @@ test.describe('Accessibility smoke', () => {
     // axe-core v4.10 cannot parse oklab() colors yet
     const unexpectedIncomplete = results.incomplete.filter((issue) => {
       if (issue.id !== 'color-contrast') return true;
-      // Check if any node contains the oklab parsing error message
-      const hasOklabError = issue.nodes?.some((node) =>
+      // Only exclude if ALL nodes have oklab parsing errors (avoid discarding unrelated issues)
+      const allNodesAreOklabErrors = issue.nodes?.every((node) =>
         node.any?.some((check) => check.message?.includes('Unable to parse color "oklab'))
       );
-      return !hasOklabError;
+      return !allNodesAreOklabErrors;
     });
     expect.soft(unexpectedIncomplete, 'axe should finish scanning').toHaveLength(0);
     expect(results.violations, `Found accessibility issues on /play: ${JSON.stringify(results.violations, null, 2)}`).toHaveLength(0);
@@ -69,11 +69,11 @@ test.describe('Accessibility smoke', () => {
     // axe-core v4.10 cannot parse oklab() colors yet
     const unexpectedIncomplete = results.incomplete.filter((issue) => {
       if (issue.id !== 'color-contrast') return true;
-      // Check if any node contains the oklab parsing error message
-      const hasOklabError = issue.nodes?.some((node) =>
+      // Only exclude if ALL nodes have oklab parsing errors (avoid discarding unrelated issues)
+      const allNodesAreOklabErrors = issue.nodes?.every((node) =>
         node.any?.some((check) => check.message?.includes('Unable to parse color "oklab'))
       );
-      return !hasOklabError;
+      return !allNodesAreOklabErrors;
     });
     expect.soft(unexpectedIncomplete, 'axe should finish scanning').toHaveLength(0);
     expect(results.violations, `Found accessibility issues on /result: ${JSON.stringify(results.violations, null, 2)}`).toHaveLength(0);


### PR DESCRIPTION
## Summary

Fix the axe-core incomplete results filter logic to properly detect oklab color parsing errors from Tailwind v4.

## Problem

The previous implementation (from PR #90) attempted to filter out known oklab parsing errors but **the filter logic was incorrect**:

```typescript
// ❌ WRONG: issue.message doesn't exist
const unexpectedIncomplete = results.incomplete.filter(
  (issue) => !(issue.id === 'color-contrast' && issue.message?.includes('Unable to parse color "oklab'))
);
```

The error message is actually nested in `issue.nodes[].any[].message`, not directly on `issue.message`. This means **the filter never worked** and would fail if oklab errors occurred.

## Solution

Properly traverse the axe-core result structure to check node messages:

```typescript
// ✅ CORRECT: Check nodes[].any[].message
const unexpectedIncomplete = results.incomplete.filter((issue) => {
  if (issue.id !== 'color-contrast') return true;
  const hasOklabError = issue.nodes?.some((node) =>
    node.any?.some((check) => check.message?.includes('Unable to parse color "oklab'))
  );
  return !hasOklabError;
});
```

## Test Plan

- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Accessibility tests pass (2/2)
- [x] E2E tests pass (11/11)
- [x] Filter logic now correctly inspects nested node messages

## Related

- Resolves Codex review feedback from PR #90
- Original issue introduced in Phase 2 (i18n/dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)