### PR TITLE
feat: expand curated.json to 20 tracks

### DIFF
--- a/workers/data/curated.json
+++ b/workers/data/curated.json
@@ -110,6 +110,116 @@
       "year": 2002,
       "youtube_url": "https://youtube.com/watch?v=gUQuBBBzx-I",
       "spotify_url": "https://open.spotify.com/track/0zx6oGNEKbOyL4J4sS39Yf"
+    },
+    {
+      "id": "011",
+      "title": "Halo Theme (Mjolnir Mix)",
+      "game": "Halo: Combat Evolved",
+      "series": "Halo",
+      "composer": "Martin O'Donnell",
+      "platform": "Xbox",
+      "year": 2001,
+      "youtube_url": "https://youtube.com/watch?v=0jXTBAGv9ZQ",
+      "spotify_url": "https://open.spotify.com/track/6n4bH0F7ggZ3kMKQvZLLOe"
+    },
+    {
+      "id": "012",
+      "title": "Tetris Theme (Korobeiniki)",
+      "game": "Tetris",
+      "series": "Tetris",
+      "composer": "Hirokazu Tanaka",
+      "platform": "Game Boy",
+      "year": 1989,
+      "youtube_url": "https://youtube.com/watch?v=NmCCQxVBfyM",
+      "spotify_url": "https://open.spotify.com/track/5J4lKPB7hsKdLlX9SpCJjm"
+    },
+    {
+      "id": "013",
+      "title": "Pokémon Center Theme",
+      "game": "Pokémon Red/Blue",
+      "series": "Pokémon",
+      "composer": "Junichi Masuda",
+      "platform": "Game Boy",
+      "year": 1996,
+      "youtube_url": "https://youtube.com/watch?v=71-ViI_TLmQ",
+      "spotify_url": "https://open.spotify.com/track/2ZiB6UjcXmbduiRWZ3rQMC"
+    },
+    {
+      "id": "014",
+      "title": "Guile's Theme",
+      "game": "Street Fighter II",
+      "series": "Street Fighter",
+      "composer": "Yoko Shimomura",
+      "platform": "Arcade",
+      "year": 1991,
+      "youtube_url": "https://youtube.com/watch?v=Iof5pRAIZmw",
+      "spotify_url": "https://open.spotify.com/track/4kLStzeMgqpuQJbZDPO0fP"
+    },
+    {
+      "id": "015",
+      "title": "Dragonborn (Skyrim Theme)",
+      "game": "The Elder Scrolls V: Skyrim",
+      "series": "The Elder Scrolls",
+      "composer": "Jeremy Soule",
+      "platform": "Multi-platform",
+      "year": 2011,
+      "youtube_url": "https://youtube.com/watch?v=AVy7YPNP_zI",
+      "spotify_url": "https://open.spotify.com/track/3RqxPSzFq4ZS7eEiR9R7nB"
+    },
+    {
+      "id": "016",
+      "title": "Still Alive",
+      "game": "Portal",
+      "series": "Portal",
+      "composer": "Jonathan Coulton",
+      "platform": "Multi-platform",
+      "year": 2007,
+      "youtube_url": "https://youtube.com/watch?v=Y6ljFaKRTrI",
+      "spotify_url": "https://open.spotify.com/track/1kBRZKOQWtfBgogPWZFSWh"
+    },
+    {
+      "id": "017",
+      "title": "The Opened Way",
+      "game": "Shadow of the Colossus",
+      "series": "Shadow of the Colossus",
+      "composer": "Kow Otani",
+      "platform": "PlayStation 2",
+      "year": 2005,
+      "youtube_url": "https://youtube.com/watch?v=dVNcmGjNW6c",
+      "spotify_url": "https://open.spotify.com/track/4YzQfYp9hqfUKLbkqjXEEh"
+    },
+    {
+      "id": "018",
+      "title": "Brinstar",
+      "game": "Metroid",
+      "series": "Metroid",
+      "composer": "Hirokazu Tanaka",
+      "platform": "NES",
+      "year": 1986,
+      "youtube_url": "https://youtube.com/watch?v=E5-EcKB-jmk",
+      "spotify_url": "https://open.spotify.com/track/6VcKP8XHPCKOdL2HGfWdm7"
+    },
+    {
+      "id": "019",
+      "title": "Last Surprise",
+      "game": "Persona 5",
+      "series": "Persona",
+      "composer": "Shoji Meguro",
+      "platform": "PlayStation 4",
+      "year": 2016,
+      "youtube_url": "https://youtube.com/watch?v=eFVj0Z6ahcI",
+      "spotify_url": "https://open.spotify.com/track/1K0z0MRtW4TYxfLBSgVqC7"
+    },
+    {
+      "id": "020",
+      "title": "Weight of the World",
+      "game": "NieR:Automata",
+      "series": "NieR",
+      "composer": "Keiichi Okabe",
+      "platform": "Multi-platform",
+      "year": 2017,
+      "youtube_url": "https://youtube.com/watch?v=YMKskuvJTcs",
+      "spotify_url": "https://open.spotify.com/track/65l53RAb6kFOWGVoXP8Ry6"
     }
   ]
 }

--- a/workers/scripts/validate-curated.ts
+++ b/workers/scripts/validate-curated.ts
@@ -1,0 +1,62 @@
+import { readFile } from 'node:fs/promises'
+import { z } from 'zod'
+
+const TrackSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  game: z.string().min(1),
+  series: z.string().optional(),
+  composer: z.string().optional(),
+  platform: z.string().optional(),
+  year: z.number().min(1980).max(2030).optional(),
+  youtube_url: z.string().url().optional(),
+  spotify_url: z.string().url().optional(),
+})
+
+const CuratedDataSchema = z.object({
+  version: z.string().regex(/^\d+\.\d+\.\d+$/),
+  tracks: z.array(TrackSchema).min(4), // Minimum 4 tracks for 4-choice questions
+})
+
+async function validateCurated(filePath: string): Promise<void> {
+  const json = JSON.parse(await readFile(filePath, 'utf-8'))
+  const result = CuratedDataSchema.safeParse(json)
+
+  if (!result.success) {
+    console.error('❌ Validation failed:')
+    console.error(result.error.format())
+    process.exit(1)
+  }
+
+  console.log('✅ Validation passed!')
+  console.log(`   Version: ${result.data.version}`)
+  console.log(`   Tracks: ${result.data.tracks.length}`)
+
+  // Check for duplicate IDs
+  const ids = result.data.tracks.map((t) => t.id)
+  const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index)
+  if (duplicates.length > 0) {
+    console.error('❌ Duplicate IDs found:', duplicates)
+    process.exit(1)
+  }
+
+  // Check for duplicate games (should have variety)
+  const games = result.data.tracks.map((t) => t.game)
+  const uniqueGames = new Set(games)
+
+  console.log(`   Unique games: ${uniqueGames.size}`)
+
+  // Ensure minimum 4 unique games for 4-choice questions
+  if (uniqueGames.size < 4) {
+    console.error('❌ Insufficient unique games: Need at least 4 unique game titles for 4-choice questions')
+    process.exit(1)
+  }
+
+  if (uniqueGames.size < games.length * 0.8) {
+    console.warn('⚠️  Low game variety (many duplicates)')
+  }
+
+  console.log('✅ All checks passed!')
+}
+
+validateCurated('./data/curated.json')


### PR DESCRIPTION
## Summary

Expanded curated data from 10 to 20 tracks to improve quiz content variety. Added validation script to ensure data quality and 4-choice question generation requirements.

## Changes

### 1. Data Expansion ([workers/data/curated.json](../blob/feat/expand-curated-data/workers/data/curated.json))

Added 10 new tracks with diverse selection:
- **Halo: Combat Evolved** (2001, Xbox) - Iconic FPS theme
- **Tetris** (1989, Game Boy) - Classic puzzle game
- **Pokémon Red/Blue** (1996, Game Boy) - Pokémon Center theme
- **Street Fighter II** (1991, Arcade) - Guile's Theme
- **The Elder Scrolls V: Skyrim** (2011, Multi) - Dragonborn
- **Portal** (2007, Multi) - Still Alive
- **Shadow of the Colossus** (2005, PS2) - The Opened Way
- **Metroid** (1986, NES) - Brinstar
- **Persona 5** (2016, PS4) - Last Surprise
- **NieR:Automata** (2017, Multi) - Weight of the World

**Diversity metrics:**
- ✅ 20 unique game titles (100% uniqueness)
- ✅ 15+ unique series
- ✅ 10+ platforms (Genesis, Wii, N64, PS, SNES, PC, PS2, Xbox, Game Boy, Arcade, PS4, Multi)
- ✅ 1986-2017 year range (31 years)

### 2. Validation Script ([workers/scripts/validate-curated.ts](../blob/feat/expand-curated-data/workers/scripts/validate-curated.ts))

Created validation script with:
- **Schema validation** using Zod (version, required fields, URL format, year range)
- **Duplicate ID detection** (ensures unique track IDs)
- **Minimum 4 unique games check** (required for 4-choice question generation)
- **Game variety warning** (alerts if <80% unique games)

Run with: `npm run validate:curated` (already defined in [workers/package.json](../blob/feat/expand-curated-data/workers/package.json))

## Test Results

```bash
$ npm run validate:curated
✅ Validation passed!
   Version: 1.0.0
   Tracks: 20
   Unique games: 20
✅ All checks passed!
```

## Related

Resolves #102

## Next Steps

After this PR is merged:
- Pipeline Worker can generate more diverse question sets
- Ready for Issue #103 (Cron Triggers implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)