### PR TITLE
feat(data): 拡張メタデータ用の検証スクリプトを追加

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,0 +1,31 @@
+name: Validate Data
+
+on:
+  pull_request:
+    paths:
+      - 'workers/data/curated.json'
+      - 'workers/scripts/validate-curated.ts'
+      - '.github/workflows/validate-data.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: workers/package-lock.json
+
+      - name: Install workers dependencies
+        working-directory: workers
+        run: npm ci
+
+      - name: Validate curated data
+        working-directory: workers
+        run: npm run validate:curated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ npm run deploy:api             # Deploy API Worker to production
 npm run deploy:pipeline        # Deploy Pipeline Worker to production
 npm run typecheck              # TypeScript type checking
 npm run lint                   # Biome lint checks
+npm run validate:curated       # Validate curated data file (curated.json)
 wrangler d1 migrations apply vgm-quiz-db --remote  # Apply DB migrations to production
 ```
 

--- a/docs/backend/curated-data-format.md
+++ b/docs/backend/curated-data-format.md
@@ -1,7 +1,7 @@
 # Curated Data Format – vgm-quiz Backend
 
 - **Status**: Draft
-- **Last Updated**: 2025-10-10
+- **Last Updated**: 2025-10-16
 - **Purpose**: Phase 1 手動キュレーションデータの形式定義
 
 ## File Location
@@ -28,15 +28,15 @@ interface Track {
   title: string             // Track title
   game: string              // Game title (正解の選択肢)
   series?: string           // Series name (e.g., "Final Fantasy")
-  composer?: string         // Composer name
+  composer: string          // Composer name
   platform?: string         // Platform (e.g., "SNES", "PlayStation")
-  year?: number             // Release year
-  youtube_url?: string      // YouTube video URL
-  spotify_url?: string      // Spotify track URL
+  year: number              // Release year
+  youtube_url: string       // YouTube video URL
+  spotify_url: string       // Spotify track URL
   // Phase 2A: Extended metadata for filtering
   difficulty?: Difficulty   // Recognition difficulty (easy/normal/hard)
-  genres?: string[]         // Genre tags (e.g., ["action", "rpg", "platformer"])
-  seriesTags?: string[]     // Series abbreviations (e.g., ["ff", "dq", "zelda", "mario"])
+  genres?: string[]         // Genre tags (non-empty if provided)
+  seriesTags?: string[]     // Series abbreviations (vocabulary controlled)
   era?: Era                 // Decade classification (80s-20s)
 }
 ```
@@ -49,14 +49,14 @@ interface Track {
 | `title` | ✅ | string | Min 1 char |
 | `game` | ✅ | string | Min 1 char, **must be unique** |
 | `series` | ❌ | string | - |
-| `composer` | ❌ | string | - |
+| `composer` | ✅ | string | Min 1 char |
 | `platform` | ❌ | string | - |
-| `year` | ❌ | number | 1980-2030 |
-| `youtube_url` | ❌ | string | Valid URL |
-| `spotify_url` | ❌ | string | Valid URL |
+| `year` | ✅ | number | 1980-2030 |
+| `youtube_url` | ✅ | string | Valid URL |
+| `spotify_url` | ✅ | string | Valid URL |
 | `difficulty` | ❌ | string | One of: easy, normal, hard |
-| `genres` | ❌ | string[] | Array of genre tags (e.g., ["rpg", "jrpg"]) |
-| `seriesTags` | ❌ | string[] | Array of series abbreviations (e.g., ["ff", "zelda"]) |
+| `genres` | ❌ | string[] | Non-empty array if provided; values must use the curated genre vocabulary below |
+| `seriesTags` | ❌ | string[] | Array of approved abbreviations (see vocabulary below) |
 | `era` | ❌ | string | One of: 80s, 90s, 00s, 10s, 20s |
 
 > `id` は Phase 1 の `tracks_normalized.external_id` にマッピングされ、再取り込み時の重複排除に利用します。
@@ -69,10 +69,10 @@ interface Track {
 - `hard`: Niche tracks or lesser-known titles
 
 **genres** - Game genre classifications (1-3 tags recommended):
-- Common tags: `rpg`, `jrpg`, `action`, `platformer`, `action-rpg`, `puzzle`, `fps`, `shooter`, `fighting`, `strategy`, `simulation`, `adventure`, `action-adventure`, `indie`, `arcade`
+- Allowed vocabulary: `action`, `action-adventure`, `action-rpg`, `adventure`, `arcade`, `fighting`, `fps`, `indie`, `jrpg`, `platformer`, `puzzle`, `rpg`, `shooter`, `simulation`, `strategy`
 
 **seriesTags** - Series abbreviations for quick filtering:
-- Examples: `ff` (Final Fantasy), `dq` (Dragon Quest), `zelda`, `mario`, `sonic`, `pokemon`, `persona`, `kh` (Kingdom Hearts)
+- Allowed vocabulary: `chrono`, `civ`, `ff`, `halo`, `kh`, `mario`, `metroid`, `nier`, `persona`, `pokemon`, `portal`, `sf`, `sonic`, `sotc`, `tes`, `tetris`, `undertale`, `xenoblade`, `zelda`
 
 **era** - Decade classification based on release year:
 - `80s`: 1980-1989
@@ -97,7 +97,7 @@ Phase 1 では、4択問題を生成するために**最低4つの異なるゲ�
 
 ## Example
 
-### Minimal (10 tracks) with Phase 2A Extended Metadata
+### Example Dataset (excerpt)
 
 ```json
 {
@@ -114,109 +114,54 @@ Phase 1 では、4択問題を生成するために**最低4つの異なるゲ�
       "youtube_url": "https://youtube.com/watch?v=SF9ZLNxHaBY",
       "spotify_url": "https://open.spotify.com/track/2MZSXhq4XDJWu6coGoXX18",
       "difficulty": "easy",
-      "genres": ["platformer", "action"],
-      "seriesTags": ["sonic"],
+      "genres": [
+        "platformer",
+        "action"
+      ],
+      "seriesTags": [
+        "sonic"
+      ],
       "era": "90s"
     },
     {
       "id": "002",
-      "title": "Super Mario Bros. Theme",
-      "game": "Super Mario Bros.",
-      "series": "Mario",
-      "composer": "Koji Kondo",
-      "platform": "NES",
-      "year": 1985,
-      "youtube_url": "https://youtube.com/watch?v=NTa6Xbzfq1U",
-      "difficulty": "easy",
-      "genres": ["platformer"],
-      "seriesTags": ["mario"],
-      "era": "80s"
-    },
-    {
-      "id": "003",
-      "title": "The Legend of Zelda Main Theme",
-      "game": "The Legend of Zelda",
-      "series": "Zelda",
-      "composer": "Koji Kondo",
-      "platform": "NES",
-      "year": 1986,
-      "difficulty": "easy",
-      "genres": ["action-adventure"],
-      "seriesTags": ["zelda"],
-      "era": "80s"
-    },
-    {
-      "id": "004",
-      "title": "One-Winged Angel",
-      "game": "Final Fantasy VII",
-      "series": "Final Fantasy",
-      "composer": "Nobuo Uematsu",
-      "platform": "PlayStation",
-      "year": 1997,
-      "youtube_url": "https://youtube.com/watch?v=t7wJ8pE2qKU",
-      "spotify_url": "https://open.spotify.com/track/0yDKn48Z6TRJdOKKvhqUhE",
-      "difficulty": "easy",
-      "genres": ["rpg", "jrpg"],
-      "seriesTags": ["ff"],
-      "era": "90s"
-    },
-    {
-      "id": "005",
-      "title": "Chemical Plant Zone",
-      "game": "Sonic the Hedgehog 2",
-      "series": "Sonic",
-      "composer": "Masato Nakamura",
-      "platform": "Genesis",
-      "year": 1992
-    },
-    {
-      "id": "006",
       "title": "Gusty Garden Galaxy",
       "game": "Super Mario Galaxy",
-      "series": "Mario",
+      "series": "Super Mario",
       "composer": "Mahito Yokota",
       "platform": "Wii",
       "year": 2007,
-      "youtube_url": "https://youtube.com/watch?v=VEIWhy-urqM"
+      "youtube_url": "https://youtube.com/watch?v=bcZhJDUFb58",
+      "spotify_url": "https://open.spotify.com/track/1rHXQ8VF9pG4jP9VZkFqVd",
+      "difficulty": "easy",
+      "genres": [
+        "platformer",
+        "adventure"
+      ],
+      "seriesTags": [
+        "mario"
+      ],
+      "era": "00s"
     },
     {
-      "id": "007",
+      "id": "003",
       "title": "Gerudo Valley",
       "game": "The Legend of Zelda: Ocarina of Time",
-      "series": "Zelda",
+      "series": "The Legend of Zelda",
       "composer": "Koji Kondo",
-      "platform": "N64",
+      "platform": "Nintendo 64",
       "year": 1998,
-      "youtube_url": "https://youtube.com/watch?v=0hEYvdMoF2g"
-    },
-    {
-      "id": "008",
-      "title": "To Zanarkand",
-      "game": "Final Fantasy X",
-      "series": "Final Fantasy",
-      "composer": "Nobuo Uematsu",
-      "platform": "PlayStation 2",
-      "year": 2001,
-      "spotify_url": "https://open.spotify.com/track/6XZoJcAY9V1ngXVCZoNjHi"
-    },
-    {
-      "id": "009",
-      "title": "Mega Man 2 - Dr. Wily's Castle",
-      "game": "Mega Man 2",
-      "series": "Mega Man",
-      "composer": "Takashi Tateishi",
-      "platform": "NES",
-      "year": 1988,
-      "youtube_url": "https://youtube.com/watch?v=WJRoRt155mA"
-    },
-    {
-      "id": "010",
-      "title": "Bloody Tears",
-      "game": "Castlevania II: Simon's Quest",
-      "series": "Castlevania",
-      "composer": "Kenichi Matsubara",
-      "platform": "NES",
-      "year": 1987
+      "youtube_url": "https://youtube.com/watch?v=Hy0aEj85ifY",
+      "spotify_url": "https://open.spotify.com/track/5a5KbMCLqIBZ7L5lq9PFkR",
+      "difficulty": "easy",
+      "genres": [
+        "action-adventure",
+        "rpg"
+      ],
+      "seriesTags": [
+        "zelda"
+      ],
+      "era": "90s"
     }
   ]
 }
@@ -309,67 +254,33 @@ function shuffleArray<T>(items: T[]): T[] {
 
 ### `workers/scripts/validate-curated.ts`
 
-```typescript
-import { readFile } from 'fs/promises'
-import { z } from 'zod'
+The Phase 2A validator enforces the extended schema and metadata rules. Highlights:
 
-const TrackSchema = z.object({
-  id: z.string().min(1),
-  title: z.string().min(1),
-  game: z.string().min(1),
-  series: z.string().optional(),
-  composer: z.string().optional(),
-  platform: z.string().optional(),
-  year: z.number().min(1980).max(2030).optional(),
-  youtube_url: z.string().url().optional(),
-  spotify_url: z.string().url().optional(),
-})
-
-const CuratedDataSchema = z.object({
-  version: z.string().regex(/^\d+\.\d+\.\d+$/),
-  tracks: z.array(TrackSchema).min(10),
-})
-
-async function validateCurated(filePath: string): Promise<void> {
-  const json = JSON.parse(await readFile(filePath, 'utf-8'))
-  const result = CuratedDataSchema.safeParse(json)
-
-  if (!result.success) {
-    console.error('❌ Validation failed:')
-    console.error(result.error.format())
-    process.exit(1)
-  }
-
-  console.log('✅ Validation passed!')
-  console.log(`   Version: ${result.data.version}`)
-  console.log(`   Tracks: ${result.data.tracks.length}`)
-
-  // Check for duplicate IDs
-  const ids = result.data.tracks.map((t) => t.id)
-  const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index)
-  if (duplicates.length > 0) {
-    console.error('❌ Duplicate IDs found:', duplicates)
-    process.exit(1)
-  }
-
-  // Check for duplicate games (should have variety)
-  const games = result.data.tracks.map((t) => t.game)
-  const uniqueGames = new Set(games)
-  if (uniqueGames.size < games.length * 0.8) {
-    console.warn('⚠️  Low game variety (many duplicates)')
-  }
-
-  console.log(`   Unique games: ${uniqueGames.size}`)
-}
-
-validateCurated('./data/curated.json')
-```
+- Required fields (`id`, `title`, `game`, `composer`, `year`, `youtube_url`, `spotify_url`) and SemVer `version` are validated with Zod.
+- Enumerated metadata: `difficulty`, `genres`, `seriesTags`, and `era` must use the approved vocabularies.
+- Track-level checks include duplicate ID detection and friendly contextual error messages.
+- Collection-level checks ensure at least four unique `game` values, with warnings for low variety.
+- Output separates errors and warnings, exiting with status code `1` on failure.
 
 ### Usage
 
 ```bash
 cd workers
 npm run validate:curated
+```
+
+### CI Integration
+
+Pull Request チェックとして `.github/workflows/validate-data.yml` を用意しており、`workers/data/curated.json` または検証スクリプトに変更が入った場合に自動で `npm run validate:curated` を実行します。手動検証に加えて、PR 上での失敗をトリガーにデータ品質を維持できます。
+
+### Sample Output
+
+```text
+✅ VALIDATION PASSED
+
+  Version: 1.0.0
+  Tracks: 20
+  Unique games: 20
 ```
 
 ## Import into D1

--- a/workers/pipeline/src/stages/publish.ts
+++ b/workers/pipeline/src/stages/publish.ts
@@ -275,7 +275,9 @@ function parseFacetArray(value: string | null): string[] {
       return []
     }
 
-    const filtered = parsed.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    const filtered = parsed.filter(
+      (item): item is string => typeof item === 'string' && item.trim().length > 0,
+    )
     return Array.from(new Set(filtered))
   } catch (error) {
     console.warn('[Publish] WARN: Failed to parse facet array', error)

--- a/workers/scripts/validate-curated.ts
+++ b/workers/scripts/validate-curated.ts
@@ -1,64 +1,273 @@
 import { readFile } from 'node:fs/promises'
-import { z } from 'zod'
+import { type ZodIssue, z } from 'zod'
+
+const VALID_DIFFICULTIES = ['easy', 'normal', 'hard'] as const
+const VALID_GENRES = [
+  'action',
+  'action-adventure',
+  'action-rpg',
+  'adventure',
+  'arcade',
+  'fighting',
+  'fps',
+  'indie',
+  'jrpg',
+  'platformer',
+  'puzzle',
+  'rpg',
+  'shooter',
+  'simulation',
+  'strategy',
+] as const
+const VALID_SERIES_TAGS = [
+  'chrono',
+  'civ',
+  'ff',
+  'halo',
+  'kh',
+  'mario',
+  'metroid',
+  'nier',
+  'persona',
+  'pokemon',
+  'portal',
+  'sf',
+  'sonic',
+  'sotc',
+  'tes',
+  'tetris',
+  'undertale',
+  'xenoblade',
+  'zelda',
+] as const
+const VALID_ERAS = ['80s', '90s', '00s', '10s', '20s'] as const
 
 const TrackSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
   game: z.string().min(1),
   series: z.string().optional(),
-  composer: z.string().optional(),
+  composer: z.string().min(1),
   platform: z.string().optional(),
-  year: z.number().min(1980).max(2030).optional(),
-  youtube_url: z.string().url().optional(),
-  spotify_url: z.string().url().optional(),
+  year: z.number().int().min(1980).max(2030),
+  youtube_url: z.string().url(),
+  spotify_url: z.string().url(),
+  difficulty: z.enum(VALID_DIFFICULTIES).optional(),
+  genres: z.array(z.enum(VALID_GENRES)).nonempty().optional(),
+  seriesTags: z.array(z.enum(VALID_SERIES_TAGS)).optional(),
+  era: z.enum(VALID_ERAS).optional(),
 })
+
+type Track = z.infer<typeof TrackSchema>
 
 const CuratedDataSchema = z.object({
   version: z.string().regex(/^\d+\.\d+\.\d+$/),
-  tracks: z.array(TrackSchema).min(4), // Minimum 4 tracks for 4-choice questions
+  tracks: z.array(z.unknown()).min(4),
 })
 
+type ValidationStats = {
+  version: string
+  trackCount: number
+  uniqueGames: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function extractTracks(value: unknown): unknown[] {
+  if (isRecord(value)) {
+    const maybeTracks = (value as { tracks?: unknown }).tracks
+    if (Array.isArray(maybeTracks)) {
+      return maybeTracks
+    }
+  }
+
+  return []
+}
+
+function getTrackId(value: unknown): string | undefined {
+  if (isRecord(value)) {
+    const maybeId = (value as { id?: unknown }).id
+    if (typeof maybeId === 'string' && maybeId.length > 0) {
+      return maybeId
+    }
+  }
+
+  return undefined
+}
+
+function formatIssuePath(path: (string | number)[]): string {
+  return path.reduce((acc, segment) => {
+    if (typeof segment === 'number') {
+      return `${acc}[${segment}]`
+    }
+
+    return acc ? `${acc}.${segment}` : segment
+  }, '')
+}
+
+function formatZodIssue(issue: ZodIssue, prefix: string): string {
+  const path = formatIssuePath(issue.path)
+  const location = path ? `'${path}'` : 'value'
+
+  if (issue.message === 'Required') {
+    return `${prefix}: ${location} is required`
+  }
+
+  if (issue.code === 'invalid_enum_value') {
+    const received = (issue as typeof issue & { received: unknown }).received
+    const options = issue.options.join(', ')
+    return `${prefix}: ${location} has invalid value '${received}'. Must be one of: ${options}`
+  }
+
+  if (issue.code === 'invalid_type') {
+    return `${prefix}: ${location} expected ${issue.expected}, received ${issue.received}`
+  }
+
+  if (issue.code === 'too_small') {
+    if (issue.type === 'array') {
+      return `${prefix}: ${location} must contain at least ${issue.minimum} item(s)`
+    }
+
+    if (issue.type === 'string') {
+      return `${prefix}: ${location} must be at least ${issue.minimum} character(s)`
+    }
+
+    if (issue.type === 'number') {
+      return `${prefix}: ${location} must be >= ${issue.minimum}`
+    }
+  }
+
+  if (issue.code === 'too_big') {
+    if (issue.type === 'number') {
+      return `${prefix}: ${location} must be <= ${issue.maximum}`
+    }
+  }
+
+  return `${prefix}: ${location} ${issue.message}`
+}
+
+function findDuplicates(values: string[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value)
+    } else {
+      seen.add(value)
+    }
+  }
+
+  return [...duplicates]
+}
+
+function printValidationResult(errors: string[], warnings: string[], stats: ValidationStats): void {
+  if (errors.length > 0) {
+    console.error('\n❌ VALIDATION FAILED\n')
+    for (const error of errors) {
+      console.error(`  • ${error}`)
+    }
+    console.error(`\nTotal errors: ${errors.length}`)
+    process.exit(1)
+  }
+
+  if (warnings.length > 0) {
+    console.warn('\n⚠️  WARNINGS\n')
+    for (const warning of warnings) {
+      console.warn(`  • ${warning}`)
+    }
+    console.warn(`\nTotal warnings: ${warnings.length}`)
+  }
+
+  console.log('\n✅ VALIDATION PASSED\n')
+  console.log(`  Version: ${stats.version}`)
+  console.log(`  Tracks: ${stats.trackCount}`)
+  console.log(`  Unique games: ${stats.uniqueGames}`)
+}
+
 async function validateCurated(filePath: string): Promise<void> {
-  const json = JSON.parse(await readFile(filePath, 'utf-8'))
-  const result = CuratedDataSchema.safeParse(json)
+  const errors: string[] = []
+  const warnings: string[] = []
 
-  if (!result.success) {
-    console.error('❌ Validation failed:')
-    console.error(result.error.format())
+  let raw: string
+  try {
+    raw = await readFile(filePath, 'utf-8')
+  } catch (error) {
+    console.error(`Failed to read ${filePath}:`, error)
     process.exit(1)
   }
 
-  console.log('✅ Validation passed!')
-  console.log(`   Version: ${result.data.version}`)
-  console.log(`   Tracks: ${result.data.tracks.length}`)
-
-  // Check for duplicate IDs
-  const ids = result.data.tracks.map((t) => t.id)
-  const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index)
-  if (duplicates.length > 0) {
-    console.error('❌ Duplicate IDs found:', duplicates)
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch (error) {
+    console.error('Invalid JSON: Could not parse curated data file')
     process.exit(1)
   }
 
-  // Check for duplicate games (should have variety)
-  const games = result.data.tracks.map((t) => t.game)
-  const uniqueGames = new Set(games)
+  const parsedCurated = CuratedDataSchema.safeParse(json)
+  let tracksSource: unknown[] = []
+  let version = 'unknown'
 
-  console.log(`   Unique games: ${uniqueGames.size}`)
+  if (!parsedCurated.success) {
+    for (const issue of parsedCurated.error.issues) {
+      errors.push(formatZodIssue(issue, 'Top-level'))
+    }
 
-  // Ensure minimum 4 unique games for 4-choice questions
-  if (uniqueGames.size < 4) {
-    console.error(
-      '❌ Insufficient unique games: Need at least 4 unique game titles for 4-choice questions',
-    )
-    process.exit(1)
+    tracksSource = extractTracks(json)
+  } else {
+    version = parsedCurated.data.version
+    tracksSource = parsedCurated.data.tracks
   }
 
-  if (uniqueGames.size < games.length * 0.8) {
-    console.warn('⚠️  Low game variety (many duplicates)')
+  const validTracks: Track[] = []
+
+  for (let index = 0; index < tracksSource.length; index += 1) {
+    const track = tracksSource[index]
+    const prefixBase = `Track ${index + 1}`
+    const trackId = getTrackId(track) ?? 'unknown'
+    const prefix = `${prefixBase} (${trackId})`
+    const result = TrackSchema.safeParse(track)
+
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        errors.push(formatZodIssue(issue, prefix))
+      }
+    } else {
+      validTracks.push(result.data)
+    }
   }
 
-  console.log('✅ All checks passed!')
+  let uniqueGameCount = 0
+
+  if (validTracks.length > 0) {
+    const duplicateIds = findDuplicates(validTracks.map((track) => track.id))
+    if (duplicateIds.length > 0) {
+      errors.push(`Duplicate track IDs found: ${duplicateIds.join(', ')}`)
+    }
+
+    const uniqueGames = new Set(validTracks.map((track) => track.game))
+    uniqueGameCount = uniqueGames.size
+
+    if (uniqueGames.size < 4) {
+      errors.push(
+        `CRITICAL: Only ${uniqueGames.size} unique games found. Minimum 4 required for choice generation.`,
+      )
+      errors.push(`Games: ${Array.from(uniqueGames).join(', ')}`)
+    } else if (uniqueGames.size < validTracks.length * 0.8) {
+      warnings.push(
+        `Low game variety: ${uniqueGames.size} unique games across ${validTracks.length} tracks.`,
+      )
+    }
+  }
+
+  printValidationResult(errors, warnings, {
+    version,
+    trackCount: tracksSource.length,
+    uniqueGames: uniqueGameCount,
+  })
 }
 
 validateCurated('./data/curated.json')


### PR DESCRIPTION
Phase 2Aで要求される、拡張トラックメタデータをサポートするためのデータ検証スクリプトを実装し、curated.jsonのデータ品質を保証します。

Closes #109

- **検証スクリプト (`workers/scripts/validate-curated.ts`):**
    - `curated.json`のスキーマを強制する、Zodベースの新しい検証スクリプトを追加。
    - 新しい任意フィールド `difficulty`, `genres`, `seriesTags`, `era` を、管理された語彙リストに照らして検証。
    - 選択肢生成に必要な「最低4つのユニークなゲーム」ルールを適用。
    - データ品質向上のため `composer`, `year`, および各種URLを必須フィールドに変更。
    - デバッグを容易にするため、トラック単位での詳細なエラー報告機能を提供。

- **CI統合:**
    - `curated.json`または検証スクリリプト自体を変更するPRに対して、検証を自動実行する新しいワークフロー (`.github/workflows/validate-data.yml`) を追加。

- **ドキュメント:**
    - `docs/backend/curated-data-format.md` を更新し、新しいスキーマ、必須フィールド、および語彙リストを反映。
    - `CLAUDE.md` に `npm run validate:curated` コマンドを追加。

- **コード品質:**
    - `pipeline.spec.ts`, `publish.ts` などの複数ファイルにわたり、Biomeの提案する修正を適用し、コードスタイルと型安全性を向上。