### PR TITLE
FE-03: Update MSW handlers and Playwright fixtures for Phase 2 API changes (Phase 2B)

### DIFF
--- a/web/mocks/fixtures/rounds/answers.ts
+++ b/web/mocks/fixtures/rounds/answers.ts
@@ -11,3 +11,10 @@ export const ANSWERS: Record<string, string> = {
   "q_0009": "a",
   "q_0010": "a"
 };
+
+// Phase 2B: Filter-specific question answers (separate from default for test isolation)
+export const FILTER_ANSWERS: Record<string, string> = {
+  "q_easy_0001": "a",
+  "q_hard_0001": "a",
+  "q_90s_0001": "a"
+};

--- a/web/mocks/fixtures/rounds/difficulty-easy.json
+++ b/web/mocks/fixtures/rounds/difficulty-easy.json
@@ -1,0 +1,51 @@
+{
+  "filters": {
+    "difficulty": "easy",
+    "era": null,
+    "series": []
+  },
+  "round": {
+    "token": "tok_easy_0001",
+    "progress": {
+      "index": 1,
+      "total": 10
+    }
+  },
+  "question": {
+    "id": "q_easy_0001",
+    "prompt": "このBGMはどのゲームのものでしょう？（簡単）",
+    "choices": [
+      {
+        "id": "a",
+        "label": "スーパーマリオ"
+      },
+      {
+        "id": "b",
+        "label": "ゼルダの伝説"
+      },
+      {
+        "id": "c",
+        "label": "ソニック"
+      },
+      {
+        "id": "d",
+        "label": "ポケモン"
+      }
+    ],
+    "artwork": {
+      "url": "https://example.com/art-easy.jpg",
+      "width": 1024,
+      "height": 1024,
+      "alt": "Easy Track Art"
+    },
+    "reveal": {
+      "links": [
+        {
+          "provider": "youtube",
+          "url": "https://www.youtube.com/watch?v=easy123"
+        }
+      ]
+    }
+  },
+  "finished": false
+}

--- a/web/mocks/fixtures/rounds/difficulty-hard.json
+++ b/web/mocks/fixtures/rounds/difficulty-hard.json
@@ -1,0 +1,51 @@
+{
+  "filters": {
+    "difficulty": "hard",
+    "era": null,
+    "series": []
+  },
+  "round": {
+    "token": "tok_hard_0001",
+    "progress": {
+      "index": 1,
+      "total": 10
+    }
+  },
+  "question": {
+    "id": "q_hard_0001",
+    "prompt": "このBGMの作曲者の名前は？（難しい）",
+    "choices": [
+      {
+        "id": "a",
+        "label": "Kei Shigema"
+      },
+      {
+        "id": "b",
+        "label": "Yoko Shimomura"
+      },
+      {
+        "id": "c",
+        "label": "Yasunori Mitsuda"
+      },
+      {
+        "id": "d",
+        "label": "Koji Kondo"
+      }
+    ],
+    "artwork": {
+      "url": "https://example.com/art-hard.jpg",
+      "width": 1024,
+      "height": 1024,
+      "alt": "Hard Track Art"
+    },
+    "reveal": {
+      "links": [
+        {
+          "provider": "youtube",
+          "url": "https://www.youtube.com/watch?v=hard123"
+        }
+      ]
+    }
+  },
+  "finished": false
+}

--- a/web/mocks/fixtures/rounds/era-90s.json
+++ b/web/mocks/fixtures/rounds/era-90s.json
@@ -1,0 +1,51 @@
+{
+  "filters": {
+    "difficulty": null,
+    "era": "90s",
+    "series": []
+  },
+  "round": {
+    "token": "tok_90s_0001",
+    "progress": {
+      "index": 1,
+      "total": 10
+    }
+  },
+  "question": {
+    "id": "q_90s_0001",
+    "prompt": "このBGMは1990年代のゲームのものです。ゲームのタイトルは？",
+    "choices": [
+      {
+        "id": "a",
+        "label": "Final Fantasy VII"
+      },
+      {
+        "id": "b",
+        "label": "The Legend of Zelda: Ocarina of Time"
+      },
+      {
+        "id": "c",
+        "label": "Chrono Trigger"
+      },
+      {
+        "id": "d",
+        "label": "Metal Gear Solid"
+      }
+    ],
+    "artwork": {
+      "url": "https://example.com/art-90s.jpg",
+      "width": 1024,
+      "height": 1024,
+      "alt": "90s Track Art"
+    },
+    "reveal": {
+      "links": [
+        {
+          "provider": "youtube",
+          "url": "https://www.youtube.com/watch?v=90s123"
+        }
+      ]
+    }
+  },
+  "finished": false
+}

--- a/web/mocks/fixtures/rounds/index.ts
+++ b/web/mocks/fixtures/rounds/index.ts
@@ -9,7 +9,12 @@ import next06 from './next.06.json';
 import next07 from './next.07.json';
 import next08 from './next.08.json';
 import next09 from './next.09.json';
+// Phase 2B: Filter-specific fixtures
+import difficultyEasyFixture from './difficulty-easy.json';
+import difficultyHardFixture from './difficulty-hard.json';
+import era90sFixture from './era-90s.json';
 import type { Question } from '@/src/features/quiz/api/types';
+import type { Difficulty, Era } from '@/src/features/quiz/api/manifest';
 
 export const TOTAL = 10;
 
@@ -30,4 +35,41 @@ export function getQuestionByIndex(index: number): Question | undefined {
     10: next09.question,
   };
   return cases[index] as Question | undefined;
+}
+
+/**
+ * Get the first question based on applied filters
+ * Phase 2B: Returns filter-specific fixture if available, falls back to default
+ * @param difficulty - Filter by difficulty level (easy/normal/hard)
+ * @param era - Filter by era (80s/90s/00s/10s/20s)
+ * @param series - Filter by game series (planned for future implementation)
+ */
+export function getFirstQuestionByFilters(
+  difficulty?: Difficulty,
+  era?: Era,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  series?: string[],
+): Question | undefined {
+  // Simple routing: check difficulty first, then era
+  // Series filtering is planned for future implementation
+  if (difficulty === 'easy') {
+    // Type assertion needed because JSON fixtures have different types
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return difficultyEasyFixture.question as any as Question;
+  }
+
+  if (difficulty === 'hard') {
+    // Type assertion needed because JSON fixtures have different types
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return difficultyHardFixture.question as any as Question;
+  }
+
+  if (era === '90s') {
+    // Type assertion needed because JSON fixtures have different types
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return era90sFixture.question as any as Question;
+  }
+
+  // Default: return first question from default fixture
+  return getQuestionByIndex(1);
 }

--- a/web/mocks/fixtures/rounds/meta.ts
+++ b/web/mocks/fixtures/rounds/meta.ts
@@ -63,5 +63,24 @@ export const META: Record<
     "trackTitle": "Track q_0010",
     "composer": "Composer q_0010",
     "youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  },
+  // Phase 2B: Filter-specific question metadata
+  "q_easy_0001": {
+    "workTitle": "Easy Game",
+    "trackTitle": "Easy Track",
+    "composer": "Easy Composer",
+    "youtube_url": "https://www.youtube.com/watch?v=easy123"
+  },
+  "q_hard_0001": {
+    "workTitle": "Hard Game",
+    "trackTitle": "Hard Track",
+    "composer": "Hard Composer",
+    "youtube_url": "https://www.youtube.com/watch?v=hard123"
+  },
+  "q_90s_0001": {
+    "workTitle": "90s Game",
+    "trackTitle": "90s Track",
+    "composer": "90s Composer",
+    "youtube_url": "https://www.youtube.com/watch?v=90s123"
   }
 };

--- a/web/src/features/quiz/api/manifest.ts
+++ b/web/src/features/quiz/api/manifest.ts
@@ -1,0 +1,47 @@
+// Manifest API types for Phase 2B
+// Describes available quiz modes, facets, and features
+
+export type Difficulty = 'easy' | 'normal' | 'hard' | 'mixed'
+export type Era = '80s' | '90s' | '00s' | '10s' | '20s' | 'mixed'
+
+export interface Mode {
+  id: string // e.g., 'vgm_v1-ja'
+  title: string // e.g., 'VGM Quiz Vol.1 (JA)'
+  defaultTotal: number // e.g., 10
+}
+
+export interface Facets {
+  difficulty: Difficulty[]
+  era: Era[]
+  series: string[] // e.g., ['ff', 'dq', 'zelda', 'mario', 'sonic', 'pokemon', 'mixed']
+}
+
+export interface Features {
+  inlinePlaybackDefault: boolean
+  imageProxyEnabled: boolean
+}
+
+export interface Manifest {
+  schema_version: number // e.g., 2
+  modes: Mode[]
+  facets: Facets
+  features: Features
+}
+
+// Request types for filtered rounds
+export interface RoundStartRequest {
+  mode?: string // defaults to first mode in manifest
+  difficulty?: Difficulty
+  era?: Era
+  series?: string[] // Can be multiple, OR'd together
+  total?: number // defaults to mode.defaultTotal
+  seed?: string // For deterministic shuffling
+}
+
+export interface RoundStartParams {
+  difficulty?: string
+  era?: string
+  series?: string | string[] // Can be query param repeated multiple times
+  total?: string
+  seed?: string
+}


### PR DESCRIPTION
## Summary

Implement Manifest API and add filter support to Rounds API for Phase 2B MSW/test infrastructure:

- Add Manifest API handler returning modes, facets (difficulty/era/series), and features
- Update Rounds API to accept and process filter query parameters with strict validation
- Create 3+ filter-specific test fixtures (difficulty-easy, difficulty-hard, era-90s)
- Implement fixture routing logic via `getFirstQuestionByFilters()`
- Define Manifest and related types in `web/src/features/quiz/api/manifest.ts`

## Changes

### New Files
- `web/src/features/quiz/api/manifest.ts` - Manifest API types and interfaces
- `web/mocks/fixtures/rounds/difficulty-easy.json` - Easy difficulty test fixture
- `web/mocks/fixtures/rounds/difficulty-hard.json` - Hard difficulty test fixture
- `web/mocks/fixtures/rounds/era-90s.json` - 1990s era test fixture

### Modified Files
- `web/mocks/handlers.ts` - Add Manifest API handler, update Rounds API for filter params with strict total validation
- `web/mocks/fixtures/rounds/index.ts` - Add `getFirstQuestionByFilters()` routing logic

## Validation Details

**total parameter validation:**
- Strict format check: `/^\d+$/` (digits only, rejects "5.5", "10abc", etc.)
- Range check: >= 1 and <= ROUND_TOTAL (10)
- Invalid values silently fall back to ROUND_TOTAL
- Prevents NaN/0 edge cases that would break progress tracking

## Verification

✅ `npm run lint` - 0 errors  
✅ `npm run typecheck` - 0 errors  
✅ `npm run test:e2e` - 11/11 tests passing  

## Related Issues

- Prerequisite: #112 (JWS token library implementation)
- Enables: #113 (filter selection UI), #115 (E2E test expansion)

🤖 Generated with Claude Code