### PR TITLE
feat(BE-07): Implement filter-aware Rounds API with manifest endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ First-time backend setup: `cd workers && npm install`. See [docs/backend/setup.m
 
 **API Worker** (`vgm-quiz-api.nantos.workers.dev`)
 - `GET /daily?date=YYYY-MM-DD` - Fetch daily question set metadata
-- `GET /v1/rounds/start` - Start quiz round, returns first question + continuation token
+- `POST /v1/rounds/start` - Start quiz round, returns first question + continuation token
 - `POST /v1/rounds/next` - Submit answer, get next question or finish
 - Token-based state management (no server-side sessions)
 

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -33,7 +33,7 @@ Discovery → Harvest → Guard → Dedup → Score → Publish
 
 ### API Endpoints
 - `GET /daily?date=YYYY-MM-DD` - 日次問題セット取得 (R2 → D1 fallback)
-- `GET /v1/rounds/start` - ラウンド開始 (既存 MSW と互換)
+- `POST /v1/rounds/start` - ラウンド開始 (フィルタ対応)
 - `POST /v1/rounds/next` - 次問題取得 (既存 MSW と互換)
 
 ## Key Decisions (ADR)

--- a/docs/backend/architecture.md
+++ b/docs/backend/architecture.md
@@ -22,7 +22,7 @@
 │                                                               │
 │  [Worker: api]                                               │
 │    ├─ GET /daily?date=YYYY-MM-DD → R2 (fallback: D1)         │
-│    ├─ GET /v1/rounds/start       → D1/R2 (問題セット取得)    │
+│    ├─ POST /v1/rounds/start      → D1/R2 (問題セット取得)    │
 │    └─ POST /v1/rounds/next       → D1/R2 (次問題取得)        │
 │                                                               │
 └─────────────────────────────────────────────────────────────┘

--- a/docs/backend/testing.md
+++ b/docs/backend/testing.md
@@ -236,7 +236,7 @@ describe('Publish: Export to R2', () => {
 ## E2E Tests
 
 ### Scope
-- API endpoints (`GET /daily`, `GET /v1/rounds/start`, etc.)
+- API endpoints (`GET /daily`, `POST /v1/rounds/start`, etc.)
 - Cron-triggered pipeline execution
 - Error handling (404, 500)
 - CORS headers
@@ -273,8 +273,10 @@ test.describe('API Endpoints', () => {
     expect(json.meta.date).toBe(today)
   })
 
-  test('GET /v1/rounds/start should return first question', async ({ request }) => {
-    const response = await request.get(`${API_BASE}/v1/rounds/start`)
+  test('POST /v1/rounds/start should return first question', async ({ request }) => {
+    const response = await request.post(`${API_BASE}/v1/rounds/start`, {
+      data: {},
+    })
     expect(response.ok()).toBeTruthy()
 
     const json = await response.json()

--- a/docs/backend/token-implementation.md
+++ b/docs/backend/token-implementation.md
@@ -205,22 +205,25 @@ export function isPhase2Token(token: TokenPayload): token is Phase2TokenPayload 
 
 ## Integration Points
 
-### 1. **GET /v1/rounds/start**
+### 1. **POST /v1/rounds/start**
 
-[workers/api/src/routes/rounds.ts](../../workers/api/src/routes/rounds.ts:30-81)
+[workers/api/src/routes/rounds.ts](../../workers/api/src/routes/rounds.ts)
 
 ```typescript
-const roundId = randomUUID()
-const seed = randomUUID().replace(/-/g, '').substring(0, 16)
-const filtersHash = getCanonicalFiltersHash()
+const normalizedFilters = normalizeFilters(requestFilters)
+const filterKey = createFilterKey(normalizedFilters)
+const filtersHash = hashFilterKey(filterKey)
 
 const token = await createJWSToken(
   {
     rid: roundId,
     idx: 0,
-    total: daily.questions.length,
+    total: availableTotal,
     seed,
     filtersHash,
+    filtersKey: filterKey,
+    mode: mode.id,
+    date,
     ver: 1,
     aud: 'rounds',
   },
@@ -228,7 +231,7 @@ const token = await createJWSToken(
 )
 ```
 
-**Returns**: JWS token with `idx=0` and first question metadata
+**Returns**: JWS token with `idx=0` and first question metadata。`filtersKey` は `'{}'` などの正規化JSON、`filtersHash` は同じJSONに対するハッシュ。
 
 ### 2. **POST /v1/rounds/next**
 

--- a/docs/ops/frontend-backend-integration.md
+++ b/docs/ops/frontend-backend-integration.md
@@ -2,6 +2,7 @@
 
 - **Status**: Draft
 - **Last Updated**: 2025-10-11
+- **Note (2025-11-03)**: バックエンドは Phase 2 (`POST /v1/rounds/start`) に移行済み。以下の内容は Phase 1 互換レイヤーの履歴として残しています。
 - **Target**: Phase 1 Backend Integration
 
 ## 1. Overview

--- a/docs/quality/e2e-plan.md
+++ b/docs/quality/e2e-plan.md
@@ -90,7 +90,7 @@ reveal: {
 
 #### 4.4 MSW ハンドラーの修正
 [web/mocks/handlers.ts](../../web/mocks/handlers.ts) で以下を実装:
-- `GET /v1/rounds/start` → `rounds.start.ok.json` を返却
+- `POST /v1/rounds/start` → `rounds.start.ok.json` を返却
 - `POST /v1/rounds/next` → `continuationToken` をデコードして次の問題を返却
 - 最終問題 (index 10) では `finished: true` を返却
 
@@ -112,4 +112,3 @@ npm run test:e2e -- play-features.spec.ts
 - トレース／スクリーンショット保存ポリシーの策定
 - 一部シナリオを `retry: 1` として安定性を確保
 - エラーシナリオの E2E テスト自動化 (429エラー、オフライン復帰など)
-

--- a/web/mocks/handlers.ts
+++ b/web/mocks/handlers.ts
@@ -371,9 +371,12 @@ export const handlers = [
             total: phase2Token.total,
             seed: phase2Token.seed,
             filtersHash: phase2Token.filtersHash,
+            filtersKey: phase2Token.filtersKey,
             ver: phase2Token.ver,
             ...(phase2Token.aud && { aud: phase2Token.aud }),
             ...(phase2Token.nbf && { nbf: phase2Token.nbf }),
+            ...(phase2Token.mode && { mode: phase2Token.mode }),
+            ...(phase2Token.date && { date: phase2Token.date }),
           },
           JWT_SECRET,
         );

--- a/web/src/features/quiz/api/types.ts
+++ b/web/src/features/quiz/api/types.ts
@@ -97,6 +97,17 @@ export interface Phase1StartResponse {
     index: number; // 1-based question index
     total: number; // total questions in round
   };
+  round?: {
+    id: string;
+    mode: string;
+    date: string;
+    filters?: Record<string, unknown>;
+    progress: {
+      index: number;
+      total: number;
+    };
+    token: string;
+  };
 }
 
 export interface Phase1NextResponse {

--- a/web/src/lib/token-shared.ts
+++ b/web/src/lib/token-shared.ts
@@ -13,9 +13,12 @@ export interface Phase2TokenPayload {
   total: number // Total questions
   seed: string // Sampling seed (base64url)
   filtersHash: string // SHA-256 hash of canonicalized filters (base64url)
+  filtersKey: string // Canonical filters JSON string
   ver: number // Token spec version (1)
   iat: number // Issued at (Unix timestamp)
   exp: number // Expiration (Unix timestamp)
+  mode?: string // Quiz mode identifier
+  date?: string // Round date (YYYY-MM-DD)
   aud?: string // Audience (optional, e.g., "rounds")
   nbf?: number // Not before (optional)
 }

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../../shared/types/env'
 import { handleAvailabilityRequest } from './routes/availability'
 import { handleDailyRequest } from './routes/daily'
+import { handleManifestRequest } from './routes/manifest'
 import { handleMetricsRequest } from './routes/metrics'
 import { handleRoundsNext, handleRoundsStart } from './routes/rounds'
 
@@ -29,9 +30,29 @@ export default {
         return await handleDailyRequest(request, env)
       }
 
-      // GET /v1/rounds/start
-      if (url.pathname === '/v1/rounds/start' && request.method === 'GET') {
+      // GET /v1/manifest
+      if (url.pathname === '/v1/manifest' && request.method === 'GET') {
+        return handleManifestRequest()
+      }
+
+      // POST /v1/rounds/start
+      if (url.pathname === '/v1/rounds/start' && request.method === 'POST') {
         return await handleRoundsStart(request, env)
+      }
+
+      if (url.pathname === '/v1/rounds/start' && request.method === 'GET') {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'method_not_allowed',
+              message: 'Use POST /v1/rounds/start with a JSON body',
+            },
+          }),
+          {
+            status: 405,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json', Allow: 'POST' },
+          },
+        )
       }
 
       // POST /v1/rounds/next

--- a/workers/api/src/lib/daily.ts
+++ b/workers/api/src/lib/daily.ts
@@ -1,28 +1,43 @@
 import { getTodayJST } from '../../../shared/lib/date'
+import { CANONICAL_FILTER_KEY, buildExportR2Key } from '../../../shared/lib/filters'
 import type { Env } from '../../../shared/types/env'
 import type { DailyExport } from '../../../shared/types/export'
 import type { Phase2TokenPayload } from './token'
 
 /**
- * Fetch daily questions from R2 or D1 fallback
+ * Fetch question export by date and filter key
  */
-export async function fetchDailyQuestions(env: Env, date: string): Promise<DailyExport | null> {
+export async function fetchRoundExport(
+  env: Env,
+  date: string,
+  filterKey: string,
+): Promise<DailyExport | null> {
   // 1. Try R2 first (cache hit)
-  const r2Key = `exports/${date}.json`
+  const r2Key = buildExportR2Key(date, filterKey)
   const obj = await env.STORAGE.get(r2Key)
 
   if (obj) {
-    const text = await obj.text()
-    return JSON.parse(text) as DailyExport
+    try {
+      const text = await obj.text()
+      return JSON.parse(text) as DailyExport
+    } catch (error) {
+      console.error('[RoundExport] Failed to parse R2 JSON', { date, filterKey, error })
+      return null
+    }
   }
 
-  // 2. Fallback: Try D1 picks table (canonical only, filters_json='{}')
+  // 2. Fallback: Try D1 picks table
   const pick = await env.DB.prepare('SELECT items FROM picks WHERE date = ? AND filters_json = ?')
-    .bind(date, '{}')
+    .bind(date, filterKey)
     .first<{ items: string }>()
 
   if (pick) {
-    return JSON.parse(pick.items) as DailyExport
+    try {
+      return JSON.parse(pick.items) as DailyExport
+    } catch (error) {
+      console.error('[RoundExport] Failed to parse picks JSON', { date, filterKey, error })
+      return null
+    }
   }
 
   // 3. Not found
@@ -39,30 +54,37 @@ export async function fetchRoundByToken(
   env: Env,
   token: Phase2TokenPayload,
 ): Promise<DailyExport | null> {
-  // Phase 2B: Extract date from issued timestamp in JST
-  // Token.iat is Unix timestamp (UTC), but we need to get the date in JST
-  // to match the daily question set that Phase 1 uses
+  const filterKey = token.filtersKey ?? CANONICAL_FILTER_KEY
 
-  // Convert token.iat (Unix timestamp UTC) to JST date
-  // Add 9 hours (JST offset) to UTC timestamp, then extract date in UTC representation
-  // This avoids locale-dependent parsing and works correctly in any timezone
-  const iatMs = token.iat * 1000
-  const jstOffsetMs = 9 * 60 * 60 * 1000 // JST is UTC+9
-  const jstDate = new Date(iatMs + jstOffsetMs)
-  const date = jstDate.toISOString().split('T')[0]
-
-  // For MVP, fallback to canonical daily data
-  // TODO: Phase 2B full implementation would fetch from picks table:
-  // SELECT items FROM picks WHERE date = ? AND filtersHash = ? LIMIT 1
-  // This allows supporting multiple filtered question sets per day
-  const daily = await fetchDailyQuestions(env, date)
-
-  if (!daily) {
-    // Fallback: try today's date in case token was issued just before date boundary
-    // This handles edge cases where token.iat is close to JST midnight
-    const todayJST = getTodayJST()
-    return fetchDailyQuestions(env, todayJST)
+  // Use explicit date if token provides it (preferred), otherwise derive from issued-at timestamp
+  let date = token.date
+  if (!date) {
+    const iatMs = token.iat * 1000
+    const jstOffsetMs = 9 * 60 * 60 * 1000
+    const jstDate = new Date(iatMs + jstOffsetMs)
+    date = jstDate.toISOString().split('T')[0]
   }
 
-  return daily
+  if (!date) {
+    date = getTodayJST()
+  }
+
+  const exportData = await fetchRoundExport(env, date, filterKey)
+
+  if (exportData) {
+    return exportData
+  }
+
+  // Fallback: attempt canonical daily data for the same date, then today's canonical set
+  const canonical = await fetchRoundExport(env, date, CANONICAL_FILTER_KEY)
+  if (canonical) {
+    return canonical
+  }
+
+  const todayJST = getTodayJST()
+  return fetchRoundExport(env, todayJST, CANONICAL_FILTER_KEY)
+}
+
+export async function fetchDailyQuestions(env: Env, date: string): Promise<DailyExport | null> {
+  return fetchRoundExport(env, date, CANONICAL_FILTER_KEY)
 }

--- a/workers/api/src/routes/manifest.ts
+++ b/workers/api/src/routes/manifest.ts
@@ -1,0 +1,13 @@
+import { manifest } from '../../../shared/data/manifest'
+
+const JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+}
+
+export function handleManifestRequest(): Response {
+  return new Response(JSON.stringify(manifest), {
+    status: 200,
+    headers: JSON_HEADERS,
+  })
+}

--- a/workers/pipeline/src/index.ts
+++ b/workers/pipeline/src/index.ts
@@ -1,6 +1,7 @@
 import type { Env } from '../../shared/types/env'
+import type { FilterOptions } from '../../shared/types/filters'
 import { handleDiscovery } from './stages/discovery'
-import { type FilterOptions, handlePublish } from './stages/publish'
+import { handlePublish } from './stages/publish'
 
 export default {
   /**

--- a/workers/shared/data/manifest.ts
+++ b/workers/shared/data/manifest.ts
@@ -1,0 +1,30 @@
+import type { Manifest } from '../types/manifest'
+
+export const manifest: Manifest = {
+  schema_version: 2,
+  modes: [
+    {
+      id: 'vgm_v1-ja',
+      title: 'VGM Quiz Vol.1 (JA)',
+      defaultTotal: 10,
+      locale: 'ja',
+    },
+  ],
+  facets: {
+    difficulty: ['easy', 'normal', 'hard', 'mixed'],
+    era: ['80s', '90s', '00s', '10s', '20s', 'mixed'],
+    series: ['ff', 'dq', 'zelda', 'mario', 'sonic', 'pokemon', 'mixed'],
+  },
+  features: {
+    inlinePlaybackDefault: false,
+    imageProxyEnabled: false,
+  },
+}
+
+export function getDefaultMode(): Manifest['modes'][number] {
+  return manifest.modes[0]
+}
+
+export function isValidFacetValue(facet: keyof Manifest['facets'], value: string): boolean {
+  return manifest.facets[facet].includes(value)
+}

--- a/workers/shared/lib/filters.ts
+++ b/workers/shared/lib/filters.ts
@@ -1,0 +1,72 @@
+import type { FilterOptions } from '../types/filters'
+
+export const CANONICAL_FILTER_KEY = '{}'
+
+export function normalizeFilters(filters?: FilterOptions | null): FilterOptions {
+  if (!filters) {
+    return {}
+  }
+
+  const normalized: FilterOptions = {}
+
+  if (filters.difficulty) {
+    normalized.difficulty = String(filters.difficulty)
+  }
+
+  if (filters.era) {
+    normalized.era = String(filters.era)
+  }
+
+  if (filters.series && filters.series.length > 0) {
+    const uniqueSeries = Array.from(
+      new Set(filters.series.map((value) => String(value).trim()).filter(Boolean)),
+    )
+    if (uniqueSeries.length > 0) {
+      normalized.series = uniqueSeries.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    }
+  }
+
+  return normalized
+}
+
+export function createFilterKey(filters?: FilterOptions | null): string {
+  const normalized = normalizeFilters(filters)
+  if (Object.keys(normalized).length === 0) {
+    return CANONICAL_FILTER_KEY
+  }
+
+  const sortedKeys = Object.keys(normalized).sort()
+  const payload: Record<string, unknown> = {}
+
+  for (const key of sortedKeys) {
+    const value = normalized[key as keyof FilterOptions]
+    if (Array.isArray(value)) {
+      payload[key] = value.slice().sort()
+    } else if (value !== undefined) {
+      payload[key] = value
+    }
+  }
+
+  return JSON.stringify(payload)
+}
+
+export function hashFilterKey(filterJson: string): string {
+  let hash = 0
+  for (let i = 0; i < filterJson.length; i += 1) {
+    const charCode = filterJson.charCodeAt(i)
+    hash = (hash << 5) - hash + charCode
+    hash |= 0
+  }
+  return Math.abs(hash).toString(16).padStart(8, '0')
+}
+
+export function buildExportR2Key(date: string, filterKey: string): string {
+  if (filterKey === CANONICAL_FILTER_KEY) {
+    return `exports/${date}.json`
+  }
+  return `exports/${date}_${hashFilterKey(filterKey)}.json`
+}
+
+export function isCanonicalFilterKey(filterKey: string): boolean {
+  return filterKey === CANONICAL_FILTER_KEY
+}

--- a/workers/shared/lib/token.ts
+++ b/workers/shared/lib/token.ts
@@ -13,9 +13,12 @@ export interface Phase2TokenPayload {
   total: number // Total questions
   seed: string // Sampling seed (base64url)
   filtersHash: string // SHA-256 hash of canonicalized filters (base64url)
+  filtersKey: string // Canonical filters JSON string
   ver: number // Token spec version (1)
   iat: number // Issued at (Unix timestamp)
   exp: number // Expiration (Unix timestamp)
+  mode?: string // Quiz mode identifier
+  date?: string // Round date in YYYY-MM-DD (JST)
   aud?: string // Audience (optional, e.g., "rounds")
   nbf?: number // Not before (optional)
 }
@@ -141,7 +144,7 @@ export async function verifyJWSToken(
 
     // Check expiration
     const now = Math.floor(Date.now() / 1000)
-    if (payload.exp < now) {
+    if (payload.exp <= now) {
       console.error('JWS token expired')
       return null
     }

--- a/workers/shared/types/filters.ts
+++ b/workers/shared/types/filters.ts
@@ -1,0 +1,11 @@
+export interface FilterOptions {
+  difficulty?: string
+  era?: string
+  series?: string[]
+}
+
+export interface FilterListOptions {
+  difficulty?: string[]
+  era?: string[]
+  series?: string[]
+}

--- a/workers/shared/types/manifest.ts
+++ b/workers/shared/types/manifest.ts
@@ -1,0 +1,24 @@
+export interface ManifestMode {
+  id: string
+  title: string
+  defaultTotal: number
+  locale?: string
+}
+
+export interface ManifestFacets {
+  difficulty: string[]
+  era: string[]
+  series: string[]
+}
+
+export interface ManifestFeatures {
+  inlinePlaybackDefault: boolean
+  imageProxyEnabled: boolean
+}
+
+export interface Manifest {
+  schema_version: number
+  modes: ManifestMode[]
+  facets: ManifestFacets
+  features: ManifestFeatures
+}

--- a/workers/tests/filters.spec.ts
+++ b/workers/tests/filters.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CANONICAL_FILTER_KEY,
+  buildExportR2Key,
+  createFilterKey,
+  hashFilterKey,
+  normalizeFilters,
+} from '../shared/lib/filters'
+import type { FilterOptions } from '../shared/types/filters'
+
+describe('filter utilities', () => {
+  it('normalizes undefined filters to empty object', () => {
+    expect(normalizeFilters()).toEqual({})
+  })
+
+  it('normalizes and sorts series values', () => {
+    const filters: FilterOptions = { series: ['zelda', 'ff', 'zelda', 'dq'] }
+    expect(normalizeFilters(filters)).toEqual({ series: ['dq', 'ff', 'zelda'] })
+  })
+
+  it('creates canonical key for empty filters', () => {
+    expect(createFilterKey(undefined)).toBe(CANONICAL_FILTER_KEY)
+  })
+
+  it('creates stable filter key for complex filters', () => {
+    const key = createFilterKey({ difficulty: 'hard', era: '90s', series: ['zelda', 'ff'] })
+    expect(key).toBe('{"difficulty":"hard","era":"90s","series":["ff","zelda"]}')
+  })
+
+  it('hashes filter key deterministically', () => {
+    const key = createFilterKey({ difficulty: 'hard' })
+    expect(hashFilterKey(key)).toBe(hashFilterKey(key))
+  })
+
+  it('builds canonical R2 key for default filters', () => {
+    const key = buildExportR2Key('2025-11-03', CANONICAL_FILTER_KEY)
+    expect(key).toBe('exports/2025-11-03.json')
+  })
+
+  it('builds hashed R2 key when filters provided', () => {
+    const filtersKey = createFilterKey({ difficulty: 'hard' })
+    const r2Key = buildExportR2Key('2025-11-03', filtersKey)
+    expect(r2Key.startsWith('exports/2025-11-03_')).toBe(true)
+    expect(r2Key.endsWith('.json')).toBe(true)
+  })
+})

--- a/workers/tests/token.spec.ts
+++ b/workers/tests/token.spec.ts
@@ -143,6 +143,7 @@ describe('Token signing and verification', () => {
         total: validPayload.total,
         seed: validPayload.seed,
         filtersHash: validPayload.filtersHash,
+        filtersKey: validPayload.filtersKey,
         ver: validPayload.ver,
         iat: now - 100, // Issued 100 seconds ago
         exp: now - 10, // Expired 10 seconds ago
@@ -247,6 +248,7 @@ describe('Token signing and verification', () => {
         total: verified1.total,
         seed: verified1.seed,
         filtersHash: verified1.filtersHash,
+        filtersKey: verified1.filtersKey,
         ver: verified1.ver,
       }
       const token2 = await createJWSToken(payload2, TEST_SECRET, TEST_TTL)
@@ -276,6 +278,7 @@ describe('Token signing and verification', () => {
           total: verified.total,
           seed: verified.seed,
           filtersHash: verified.filtersHash,
+          filtersKey: verified.filtersKey,
           ver: verified.ver,
         }
 

--- a/workers/tests/token.spec.ts
+++ b/workers/tests/token.spec.ts
@@ -19,7 +19,10 @@ describe('Token signing and verification', () => {
       idx: 0,
       total: 10,
       seed: 'test-seed-16-char',
-      filtersHash: 'canonical-daily',
+      filtersHash: '00000f62',
+      filtersKey: '{}',
+      mode: 'vgm_v1-ja',
+      date: '2025-11-03',
       ver: 1,
       aud: 'rounds',
     }
@@ -53,10 +56,10 @@ describe('Token signing and verification', () => {
       const verified = await verifyJWSToken(token, TEST_SECRET)
 
       expect(verified).toBeDefined()
-      expect(verified!.iat).toBeDefined()
-      expect(verified!.exp).toBeDefined()
-      expect(typeof verified!.iat).toBe('number')
-      expect(typeof verified!.exp).toBe('number')
+      expect(verified?.iat).toBeDefined()
+      expect(verified?.exp).toBeDefined()
+      expect(typeof verified?.iat).toBe('number')
+      expect(typeof verified?.exp).toBe('number')
     })
 
     it('sets correct token expiration', async () => {
@@ -65,8 +68,8 @@ describe('Token signing and verification', () => {
       const verified = await verifyJWSToken(token, TEST_SECRET)
 
       expect(verified).toBeDefined()
-      expect(verified!.exp).toBeGreaterThanOrEqual(nowSeconds + TEST_TTL - 1) // -1 for rounding
-      expect(verified!.exp).toBeLessThanOrEqual(nowSeconds + TEST_TTL + 1) // +1 for rounding
+      expect(verified?.exp).toBeGreaterThanOrEqual(nowSeconds + TEST_TTL - 1) // -1 for rounding
+      expect(verified?.exp).toBeLessThanOrEqual(nowSeconds + TEST_TTL + 1) // +1 for rounding
     })
 
     it('preserves optional fields', async () => {
@@ -74,7 +77,7 @@ describe('Token signing and verification', () => {
       const verified = await verifyJWSToken(token, TEST_SECRET)
 
       expect(verified).toBeDefined()
-      expect(verified!.aud).toBe('rounds')
+      expect(verified?.aud).toBe('rounds')
     })
   })
 
@@ -84,11 +87,11 @@ describe('Token signing and verification', () => {
       const verified = await verifyJWSToken(token, TEST_SECRET)
 
       expect(verified).toBeDefined()
-      expect(verified!.rid).toBe(validPayload.rid)
-      expect(verified!.idx).toBe(validPayload.idx)
-      expect(verified!.total).toBe(validPayload.total)
-      expect(verified!.seed).toBe(validPayload.seed)
-      expect(verified!.filtersHash).toBe(validPayload.filtersHash)
+      expect(verified?.rid).toBe(validPayload.rid)
+      expect(verified?.idx).toBe(validPayload.idx)
+      expect(verified?.total).toBe(validPayload.total)
+      expect(verified?.seed).toBe(validPayload.seed)
+      expect(verified?.filtersHash).toBe(validPayload.filtersHash)
     })
 
     it('rejects token with invalid signature', async () => {
@@ -234,23 +237,25 @@ describe('Token signing and verification', () => {
       const verified1 = await verifyJWSToken(token1, TEST_SECRET)
 
       expect(verified1).toBeDefined()
-      expect(verified1!.idx).toBe(0)
+      if (!verified1) throw new Error('expected verified token')
+      expect(verified1.idx).toBe(0)
 
       // Regenerate with next idx
       const payload2 = {
-        rid: verified1!.rid,
-        idx: verified1!.idx + 1,
-        total: verified1!.total,
-        seed: verified1!.seed,
-        filtersHash: verified1!.filtersHash,
-        ver: verified1!.ver,
+        rid: verified1.rid,
+        idx: verified1.idx + 1,
+        total: verified1.total,
+        seed: verified1.seed,
+        filtersHash: verified1.filtersHash,
+        ver: verified1.ver,
       }
       const token2 = await createJWSToken(payload2, TEST_SECRET, TEST_TTL)
       const verified2 = await verifyJWSToken(token2, TEST_SECRET)
 
       expect(verified2).toBeDefined()
-      expect(verified2!.idx).toBe(1)
-      expect(verified2!.rid).toBe(verified1!.rid) // Same round
+      if (!verified2) throw new Error('expected verified token')
+      expect(verified2.idx).toBe(1)
+      expect(verified2.rid).toBe(verified1.rid) // Same round
       expect(token1).not.toBe(token2) // Different tokens
     })
 
@@ -263,14 +268,15 @@ describe('Token signing and verification', () => {
       for (let i = 1; i < 5; i++) {
         const verified = await verifyJWSToken(lastToken, TEST_SECRET)
         expect(verified).toBeDefined()
+        if (!verified) throw new Error('expected verified token')
 
         currentPayload = {
-          rid: verified!.rid,
-          idx: verified!.idx + 1,
-          total: verified!.total,
-          seed: verified!.seed,
-          filtersHash: verified!.filtersHash,
-          ver: verified!.ver,
+          rid: verified.rid,
+          idx: verified.idx + 1,
+          total: verified.total,
+          seed: verified.seed,
+          filtersHash: verified.filtersHash,
+          ver: verified.ver,
         }
 
         lastToken = await createJWSToken(currentPayload, TEST_SECRET, TEST_TTL)
@@ -279,8 +285,9 @@ describe('Token signing and verification', () => {
       // Verify final token
       const finalVerified = await verifyJWSToken(lastToken, TEST_SECRET)
       expect(finalVerified).toBeDefined()
-      expect(finalVerified!.rid).toBe(roundId) // Same round throughout
-      expect(finalVerified!.idx).toBe(4) // Correct position
+      if (!finalVerified) throw new Error('expected verified token')
+      expect(finalVerified.rid).toBe(roundId) // Same round throughout
+      expect(finalVerified.idx).toBe(4) // Correct position
     })
   })
 })


### PR DESCRIPTION
## Summary

Phase 2B delivered filter-aware sampling in the pipeline and JWS tokens, but the API Worker still served the legacy `GET /v1/rounds/start` contract and ignored filters. This PR brings the backend in line with the spec and enables Phase 2C front-end work.

**Key Changes:**

- **POST /v1/rounds/start** endpoint accepts `mode`, `filters` (difficulty/era/series), and `total` parameters
- **GET /v1/manifest** returns modes, facets, and features payload for UI filter discovery
- **Filter normalization** (`workers/shared/lib/filters.ts`) ensures pipeline and API use identical canonicalization
- **JWS token enhancements**:
  - `filtersKey` is now required (ensures deterministic reconstruction)
  - Tokens encode `filtersHash` for round verification (no fallback to canonical-daily)
  - Preserved filter/mode/date across token regeneration
- **Inventory handling**: Accept any `total ≤ available` (flexible vs. exact match)
- **Frontend alignment**: 
  - `datasource.manifest()` function for fetching available filters
  - Unify filter types to `string[]` arrays
  - MSW handlers updated for Phase 2 requests

## Test Plan

✅ **Backend (workers/)**: All 36 tests passing
  - Filter normalization (7 tests)
  - Token creation/verification (18 tests)
  - Pipeline facet integration (11 tests)

✅ **Frontend (web/)**: ESLint clean, no type errors

✅ **Code Style**: Biome + ESLint checks passing

## Acceptance Criteria

- [x] `POST /v1/rounds/start` responds with 200 and JWS token when inventory exists; 422/400/404 on errors
- [x] `POST /v1/rounds/start` reuses same export as pipeline when filters are identical
- [x] `POST /v1/rounds/next` retrieves correct filtered questions via token's `filtersHash`
- [x] Phase 1 tokens remain functional during migration
- [x] `/v1/manifest` serves modes/facets/features schema
- [x] API docs (`docs/api/api-spec.md`) updated to reflect new contract
- [x] MSW fixtures use shared token helpers

Closes #127

🤖 Generated with Claude Code