### PR TITLE
feat: add runtime validation guardrails

### DIFF
--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -92,77 +92,67 @@
 
 ---
 
-## Phase 3 - Spotify API統合
+## Phase 3 - Observability & Guardrails
 
-**ゴール**: DiscoveryとHarvestステージをSpotify APIで自動化
+**ゴール**: 完全自動クイズ生成へ進む前に、現行フィルタ配信を計測・監視可能にし、失敗時でも即復旧できる体制を築く。手動介入ゼロで安定運用できる仕組みを整備する。
 
-**ステータス**: 将来計画
+**ステータス**: 計画中（2025-11-15 時点）
 
-**開始予定**: Phase 2安定化後（2025-11-15 時点で着手条件を満たし、キックオフ可）
+**開始予定**: Phase 2 安定確認後すぐ（2025-11 下旬見込み）
 
-### 計画中の機能
+### サブフェーズ別の状況と担当Issue
 
-#### Backend
-- [ ] **Spotify API統合**
-  - OAuth2認証
-  - プレイリスト発見
-  - トラックメタデータ拡充
+#### Phase 3A - 観測性基盤（計画中）
+- [ ] #75 Ops: Web Vitals & custom performance marks（P2, area:ops）
+- [ ] #76 Ops: CI Lighthouse smoke tests（P2, area:ops）
+- [ ] #134 OPS-03: Observability dashboard & Slack alerts（P2, area:ops）
 
-- [ ] **Discoveryステージ自動化**
-  - 定期的なSpotifyプレイリストスキャン
-  - プレイリスト人気度ベースの優先度スコアリング
+#### Phase 3B - Guardrails（計画中）
+- [ ] #65 FE: Runtime type guards for API responses（P1, area:fe）
+- [ ] #77 FE: Contract tests for metrics/reveal payloads（P2, area:fe）
+- [ ] #135 FE-Guardrails: Enforce contract tests in CI（P2, area:fe）
 
-- [ ] **Harvestステージ実装**
-  - Spotify APIからトラックメタデータを取得
-  - プレビューURL保存 (30秒クリップ)
-  - メタデータ正規化 (作曲者、ゲームタイトル抽出)
+#### Phase 3C - Runbook & Metrics Docs（計画中）
+- [ ] #32 DOCS-01: quality/metrics.md（P2, area:docs）
+- [ ] #33 DOCS-02: measurement-plan.md（P2, area:docs）
+- [ ] #35 DOCS-04: audio-playback runbook（P2, area:docs）
+- [ ] #37 OPS-02: レート制限/署名鍵ローテーション運用メモ（P3, area:ops）
 
-#### データパイプライン
-- [ ] **Guardステージ** (品質チェック)
-  - ルールベース検証 (メタデータ完全性)
-  - エッジケース用の手動レビューキュー
-
-- [ ] **Dedupステージ** (重複検出)
-  - タイトル/ゲームで類似トラックをクラスタリング
-  - 正規トラック選択
-
-#### Data
-- [ ] 100%手動キュレーションからハイブリッドモデルへ移行
-- [ ] curated.jsonをシード/フォールバックデータとして維持
+#### Phase 3D - データ冗長性（計画中）
+- [ ] #31 DATA-03: バックアップ在庫追加（P3, area:data）
+- [ ] #136 DATA-Backup-Automation: retain 14d of daily presets（P2, area:data）
 
 ### 成功基準
-- [ ] パイプラインが週50+トラックを自動発見
-- [ ] Guardステージが95%以上のメタデータ品質を維持
-- [ ] Dedupステージが重複を80%以上削減
+- Lighthouse/Perf smoke がCIで自動実行され、しきい値超過時にアラート/ブロックできる
+- Web Vitals・custom metrics が集計され、目標値とアラートしきい値が定義済み
+- `/v1/rounds/start` とメトリクスイベントのランタイム型検証が追加され、検証失敗時のログ/アラートが用意されている
+- Runbookとメトリクス定義が公開され、オンボーディング無しで運用可能
+- バックアップ在庫（R2スナップショット）が「自動生成停止後も少なくとも14日分の新規ラウンド」を供給できる
 
 ---
 
-## Phase 4+ - 将来の拡張
+## Phase 4+ - Autonomous Content Pipeline
 
-**ステータス**: バックログ / アイデア
+**ビジョン**: 「完全自動でデータ収集・作問・配信し続ける」最終ゴールに向かう長期フェーズ。Phase 3で整備したガードレール上で、新しいコンテンツ取得チャネルや高度なゲーム体験を段階的に導入する。
 
-### 候補機能
+### コアストリーム
+1. **Content Acquisition Automation**
+   - Spotify / YouTube / Apple Music など複数ソースの並行調査
+   - Discovery/Harvest/Guard/Dedup 各ステージの自動化
+   - ライセンス・レート制限・OAuth 運用を Runbook 化
+2. **Adaptive Gameplay**
+   - 難易度自動調整、モード追加（作曲者モード、年代モードなど）
+   - パーソナライズ配信ロジック（ユーザ行動ベース）
+3. **Social & Sharing**
+   - リーダーボード、チャレンジリンク、SNSシェア
+4. **Ops & Intelligence**
+   - 予測的スケジューラ、異常検知、MLベースの品質スコアリング
 
-#### コンテンツ拡張
-- [ ] YouTube統合 (音声抽出、ML品質スコアリング)
-- [ ] Apple Music統合
-- [ ] ユーザー投稿トラック (モデレーション必要)
+### ガードレール
+- 各ストリームは Phase 3 のメトリクス/Runbook を前提に、Proof-of-Concept → ガード付き本番化の順で進める
+- 新規ソース追加ごとに「計測/失敗検知/ロールバック」手順を必須化し、最終ゴールの“完全自動化”を段階的に達成する
 
-#### ゲームプレイ
-- [ ] 複数クイズモード (作曲者モード、年代モードなど)
-- [ ] ユーザーパフォーマンスベースの難易度調整
-- [ ] コンボ/連続正解ボーナス
-
-#### ソーシャル
-- [ ] リーダーボード (サーバー側スコア保存)
-- [ ] SNSシェア
-- [ ] フレンドチャレンジ
-
-#### 運用
-- [ ] 行動スコアリング (ML基づく難易度予測)
-- [ ] 自動スケジューリング (最適な問題ローテーション)
-- [ ] パイプライン障害アラート (Slack/Emailウェブフック)
-- [ ] メトリクスダッシュボード (Grafana/Cloudflare Analytics)
+---
 
 ---
 

--- a/docs/issues/40-fe-runtime-type-guards-for-api-and-metrics.md
+++ b/docs/issues/40-fe-runtime-type-guards-for-api-and-metrics.md
@@ -1,0 +1,34 @@
+---
+id: 40
+issue: 65
+slug: fe-runtime-type-guards-for-api-and-metrics
+title: "FE: Runtime type guards for API responses and metrics payloads"
+labels: ["type:task", "area:fe", "phase:3", "priority:P1", "key:FE-TYPE-GUARD"]
+status: "in-progress"
+updated: 2025-11-15
+owner: "frontend"
+links:
+  roadmap: ../dev/roadmap.md#phase-3---observability--guardrails
+  github: https://github.com/nantes-rfli/vgm-quiz/issues/65
+---
+
+## 概要
+Phase 3 (Observability & Guardrails) のガードレール強化タスク。フロントエンドが `/v1/manifest`, `/v1/rounds/start`, `/v1/rounds/next` のレスポンスをランタイム検証し、メトリクス送信ペイロードも契約違反を検知できるようにする。MVP 時点では型アサーションに頼っていたが、Phase 3 では JWS 化したバックエンドとの契約破りを早期検出する必要がある。
+
+## 2025-11-15 実施内容
+- `zod@3` を依存追加し、Manifest/Phase1レスポンス/メトリクスペイロード用スキーマを新設。
+- `web/src/features/quiz/datasource.ts` の `fetchJson` にスキーマ検証を組み込み、Zod 失敗時は `ApiError('decode')` を投げるよう統一。
+- `web/src/features/quiz/api/manifest.ts` で Manifest キャッシュ読み込み時にも検証を入れ、破損キャッシュを自動破棄。
+- メトリクスクライアントで `PendingEvent`/バッチの検証、attr のシリアライズ正規化、破損キューの自動廃棄を実装。
+- `tests/unit/apiSchemas.spec.ts` を追加し、Zod スキーマの happy / unhappy path をカバー。
+- 既存の metrics contract test を拡張し、未定義 attr 除去＆破損イベント除外の挙動を検証。
+- `npm run test:unit` 実行済み（Vitest 45 tests）。
+
+## 未完了タスク / フォローアップ
+1. #77 (FE Contract tests for metrics/reveal payloads) で Phase 3B の自動テスト統合を継続。
+2. エラー監視: `ApiError('decode')` 発生を Sentry / ログメトリクスで可視化（Observability サブフェーズと連携）。
+3. Manifest schema が増えた場合は `docs/api/api-spec.md` とスキーマの同期を忘れない。
+
+## メモ
+- Node 25 系では `console.warn(ZodError)` がクラッシュするため、`logMetricsWarning` では `error.message` のみを出力し安全側に倒している。
+- `localStorage` を多用するテストのため、Vitest setup で in-memory storage polyfill を整備済み。

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,8 @@
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.2",
@@ -210,6 +211,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -256,6 +258,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2040,6 +2043,7 @@
       "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.55.1"
       },
@@ -2902,6 +2906,7 @@
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2980,6 +2985,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -3636,6 +3642,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4966,7 +4973,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -5368,6 +5376,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5542,6 +5551,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7623,6 +7633,7 @@
       "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.5.4",
         "cssstyle": "^5.3.0",
@@ -8520,6 +8531,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/cookie": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
@@ -9235,6 +9247,7 @@
       "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9287,6 +9300,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9507,6 +9521,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9516,6 +9531,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10778,6 +10794,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10976,6 +10993,7 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -11141,6 +11159,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11289,6 +11308,7 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -11405,6 +11425,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11892,7 +11913,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,8 @@
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",

--- a/web/src/features/quiz/api/schemas.ts
+++ b/web/src/features/quiz/api/schemas.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod'
+import type { Phase1Choice, Phase1Question, Phase1Reveal, Phase1StartResponse, Phase1NextResponse } from './types'
+
+const DIFFICULTY_VALUES = ['easy', 'normal', 'hard', 'mixed'] as const
+const ERA_VALUES = ['80s', '90s', '00s', '10s', '20s', 'mixed'] as const
+
+export const DifficultySchema = z.enum(DIFFICULTY_VALUES)
+export type Difficulty = (typeof DIFFICULTY_VALUES)[number]
+
+export const EraSchema = z.enum(ERA_VALUES)
+export type Era = (typeof ERA_VALUES)[number]
+
+export const ModeSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  defaultTotal: z.number().int().min(1).max(100),
+})
+
+export const FacetsSchema = z.object({
+  difficulty: z.array(DifficultySchema).nonempty(),
+  era: z.array(EraSchema).nonempty(),
+  series: z.array(z.string().min(1)).nonempty(),
+})
+
+export const FeaturesSchema = z.object({
+  inlinePlaybackDefault: z.boolean(),
+  imageProxyEnabled: z.boolean(),
+})
+
+export const ManifestSchema = z.object({
+  schema_version: z.number().int().nonnegative(),
+  modes: z.array(ModeSchema).nonempty(),
+  facets: FacetsSchema,
+  features: FeaturesSchema,
+})
+
+export type Mode = z.infer<typeof ModeSchema>
+export type Facets = z.infer<typeof FacetsSchema>
+export type Features = z.infer<typeof FeaturesSchema>
+export type Manifest = z.infer<typeof ManifestSchema>
+
+const RoundProgressSchema = z.object({
+  index: z.number().int().min(0),
+  total: z.number().int().min(1),
+})
+
+const Phase1ChoiceSchema: z.ZodType<Phase1Choice> = z.object({
+  id: z.string().min(1),
+  text: z.string().min(1),
+})
+
+const Phase1QuestionSchema: z.ZodType<Phase1Question> = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+})
+
+const Phase1RevealSchema: z.ZodType<Phase1Reveal> = z.object({
+  title: z.string().min(1),
+  game: z.string().min(1),
+  composer: z.string().optional(),
+  year: z.number().int().optional(),
+  platform: z.string().optional(),
+  series: z.string().optional(),
+  youtube_url: z.string().url().optional(),
+  spotify_url: z.string().url().optional(),
+  apple_music_url: z.string().url().optional(),
+  other_url: z.string().url().optional(),
+})
+
+export const Phase1StartResponseSchema: z.ZodType<Phase1StartResponse> = z.object({
+  question: Phase1QuestionSchema,
+  choices: z.array(Phase1ChoiceSchema).min(1),
+  continuationToken: z.string().min(1),
+  progress: RoundProgressSchema.optional(),
+  round: z
+    .object({
+      id: z.string().min(1),
+      mode: z.string().min(1),
+      date: z.string().min(1),
+      filters: z.record(z.string(), z.unknown()).optional(),
+      progress: RoundProgressSchema,
+      token: z.string().min(1),
+    })
+    .optional(),
+})
+
+export const Phase1NextResponseSchema: z.ZodType<Phase1NextResponse> = z.object({
+  result: z.object({
+    correct: z.boolean(),
+    correctAnswer: z.string().min(1),
+    reveal: Phase1RevealSchema,
+  }),
+  question: Phase1QuestionSchema.optional(),
+  choices: z.array(Phase1ChoiceSchema).optional(),
+  continuationToken: z.string().optional(),
+  progress: RoundProgressSchema.optional(),
+  finished: z.boolean(),
+})

--- a/web/src/features/quiz/api/schemas.ts
+++ b/web/src/features/quiz/api/schemas.ts
@@ -14,6 +14,7 @@ export const ModeSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
   defaultTotal: z.number().int().min(1).max(100),
+  locale: z.string().min(2).optional(),
 })
 
 export const FacetsSchema = z.object({

--- a/web/src/lib/metrics/schemas.ts
+++ b/web/src/lib/metrics/schemas.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+import { METRICS_EVENT_NAMES } from './types'
+import type { MetricsBatch, MetricsEvent, PendingEvent } from './types'
+
+type MetricsAttributeValue =
+  | string
+  | number
+  | boolean
+  | null
+  | MetricsAttributeValue[]
+  | { [key: string]: MetricsAttributeValue }
+
+const metricsAttributeValueSchema: z.ZodType<MetricsAttributeValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(metricsAttributeValueSchema).max(50),
+    z.record(metricsAttributeValueSchema),
+  ]),
+)
+
+export const MetricsEventSchema = z.object({
+  id: z.string().min(1),
+  name: z.enum(METRICS_EVENT_NAMES),
+  ts: z.string().min(1),
+  round_id: z.string().min(1).optional(),
+  question_idx: z.number().int().min(0).optional(),
+  attrs: z.record(metricsAttributeValueSchema).optional(),
+}) satisfies z.ZodType<MetricsEvent>
+
+export const PendingEventSchema = MetricsEventSchema.extend({
+  retryCount: z.number().int().min(0),
+  nextAttempt: z.number().int().min(0),
+  idempotencyKey: z.string().min(1),
+}) satisfies z.ZodType<PendingEvent>
+
+export const MetricsBatchSchema = z.object({
+  client: z.object({
+    client_id: z.string().min(1),
+    app_version: z.string().min(1).optional(),
+    tz: z.string().min(1).optional(),
+  }),
+  events: z.array(MetricsEventSchema).nonempty(),
+}) satisfies z.ZodType<MetricsBatch>

--- a/web/src/lib/metrics/types.ts
+++ b/web/src/lib/metrics/types.ts
@@ -1,13 +1,16 @@
-export type MetricsEventName =
-  | 'answer_select'
-  | 'answer_result'
-  | 'quiz_complete'
-  | 'reveal_open_external'
-  | 'embed_error'
-  | 'embed_fallback_to_link'
-  | 'settings_inline_toggle'
-  | 'settings_theme_toggle'
-  | 'settings_locale_toggle';
+export const METRICS_EVENT_NAMES = [
+  'answer_select',
+  'answer_result',
+  'quiz_complete',
+  'reveal_open_external',
+  'embed_error',
+  'embed_fallback_to_link',
+  'settings_inline_toggle',
+  'settings_theme_toggle',
+  'settings_locale_toggle',
+] as const;
+
+export type MetricsEventName = (typeof METRICS_EVENT_NAMES)[number];
 
 export interface MetricsEvent {
   id: string;

--- a/web/tests/unit/apiSchemas.spec.ts
+++ b/web/tests/unit/apiSchemas.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { ManifestSchema, Phase1NextResponseSchema, Phase1StartResponseSchema } from '@/src/features/quiz/api/schemas'
+
+const baseStartResponse = {
+  question: { id: 'q-1', title: 'Question 1' },
+  choices: [
+    { id: 'c-1', text: 'Option 1' },
+    { id: 'c-2', text: 'Option 2' },
+  ],
+  continuationToken: 'token-123',
+  progress: { index: 1, total: 10 },
+}
+
+const baseNextResponse = {
+  result: {
+    correct: true,
+    correctAnswer: 'c-1',
+    reveal: {
+      title: 'Track',
+      game: 'Game',
+    },
+  },
+  finished: false,
+}
+
+const baseManifest = {
+  schema_version: 2,
+  modes: [{ id: 'vgm_v1-ja', title: 'Vol 1', defaultTotal: 10 }],
+  facets: {
+    difficulty: ['easy', 'normal', 'hard', 'mixed'],
+    era: ['80s', '90s'],
+    series: ['ff'],
+  },
+  features: {
+    inlinePlaybackDefault: false,
+    imageProxyEnabled: false,
+  },
+}
+
+describe('API schemas', () => {
+  it('accepts valid Phase1 start response and rejects malformed payloads', () => {
+    expect(() => Phase1StartResponseSchema.parse(baseStartResponse)).not.toThrow()
+
+    const invalid = { ...baseStartResponse }
+    delete (invalid as { continuationToken?: string }).continuationToken
+    expect(Phase1StartResponseSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  it('validates Phase1 next responses', () => {
+    expect(() => Phase1NextResponseSchema.parse(baseNextResponse)).not.toThrow()
+
+    const invalid = {
+      ...baseNextResponse,
+      result: {
+        ...baseNextResponse.result,
+        correctAnswer: '',
+      },
+    }
+
+    expect(Phase1NextResponseSchema.safeParse(invalid).success).toBe(false)
+  })
+
+  it('ensures manifest responses include required facets', () => {
+    expect(() => ManifestSchema.parse(baseManifest)).not.toThrow()
+
+    const invalidManifest = {
+      ...baseManifest,
+      facets: {
+        ...baseManifest.facets,
+        series: [],
+      },
+    }
+
+    expect(ManifestSchema.safeParse(invalidManifest).success).toBe(false)
+  })
+})

--- a/web/tests/unit/setup.ts
+++ b/web/tests/unit/setup.ts
@@ -1,5 +1,54 @@
 import { afterEach, beforeEach, vi } from 'vitest';
 
+function createMemoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? map.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  } satisfies Storage;
+}
+
+function ensureStorage(target: 'localStorage' | 'sessionStorage'): Storage {
+  const globalTarget = globalThis as Record<string, unknown>;
+  const existing = globalTarget[target] as Storage | undefined;
+  if (existing && typeof existing.clear === 'function') {
+    return existing;
+  }
+  const storage = createMemoryStorage();
+  Object.defineProperty(globalThis, target, {
+    configurable: true,
+    writable: true,
+    value: storage,
+  });
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, target, {
+      configurable: true,
+      writable: true,
+      value: storage,
+    });
+  }
+  return storage;
+}
+
+ensureStorage('localStorage');
+ensureStorage('sessionStorage');
+
 beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear?.();

--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -17,7 +17,7 @@
         "tsx": "^4.11.0",
         "typescript": "^5.7.0",
         "vitest": "^3.2.4",
-        "wrangler": "^4.43.0"
+        "wrangler": "^4.47.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -198,14 +198,14 @@
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.7.tgz",
-      "integrity": "sha512-HtZuh166y0Olbj9bqqySckz0Rw9uHjggJeoGbDx5x+sgezBXlxO6tQSig2RZw5tgObF8mWI8zaPvQMkQZtAODw==",
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.10.tgz",
+      "integrity": "sha512-mvsNAiJSduC/9yxv1ZpCxwgAXgcuoDvkl8yaHjxoLpFxXy2ugc6TZK20EKgv4yO0vZhAEKwqJm+eGOzf8Oc45w==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
-        "unenv": "2.0.0-rc.21",
-        "workerd": "^1.20250927.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "^1.20251106.1"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20251008.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251008.0.tgz",
-      "integrity": "sha512-yph0H+8mMOK5Z9oDwjb8rI96oTVt4no5lZ43aorcbzsWG9VUIaXSXlBBoB3von6p4YCRW+J3n36fBM9XZ6TLaA==",
+      "version": "1.20251109.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251109.0.tgz",
+      "integrity": "sha512-GAYXHOgPTJm6F+mOt0/Zf+rL+xPfMp8zAxGN4pqkzJ6QVQA/mNVMMuj22dI5x8+Ey+lCulKC3rNs4K3VE12hlA==",
       "cpu": [
         "x64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20251008.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251008.0.tgz",
-      "integrity": "sha512-Yc4lMGSbM4AEtYRpyDpmk77MsHb6X2BSwJgMgGsLVPmckM7ZHivZkJChfcNQjZ/MGR6nkhYc4iF6TcVS+UMEVw==",
+      "version": "1.20251109.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251109.0.tgz",
+      "integrity": "sha512-fpLJvZi3i+btgrXJcOtKYrbmdnHVTKpaZigoKIcpBX4mbwxUh/GVbrCmOqLebr57asQC+PmBfghUEYniqRgnhA==",
       "cpu": [
         "arm64"
       ],
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20251008.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251008.0.tgz",
-      "integrity": "sha512-AjoQnylw4/5G6SmfhZRsli7EuIK7ZMhmbxtU0jkpciTlVV8H01OsFOgS1d8zaTXMfkWamEfMouy8oH/L7B9YcQ==",
+      "version": "1.20251109.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251109.0.tgz",
+      "integrity": "sha512-5NjCnXQoaySFAGGn10w0rPfmEhTSKTP/k7f3aduvt1syt462+66X7luOME/k2x5EB/Z5L8xvwf3/LejSSZ4EVA==",
       "cpu": [
         "x64"
       ],
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20251008.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251008.0.tgz",
-      "integrity": "sha512-hRy9yyvzVq1HsqHZUmFkAr0C8JGjAD/PeeVEGCKL3jln3M9sNCKIrbDXiL+efe+EwajJNNlDxpO+s30uVWVaRg==",
+      "version": "1.20251109.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251109.0.tgz",
+      "integrity": "sha512-f2AeJlpSwrEvEV57+JU+vRPL8c/Dv8nwY4XW+YwnzPo2TpbI/zzqloPXQ6PY79ftDfEsJJPzQuaDDPq3UOGJQA==",
       "cpu": [
         "arm64"
       ],
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20251008.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251008.0.tgz",
-      "integrity": "sha512-Gm0RR+ehfNMsScn2pUcn3N9PDUpy7FyvV9ecHEyclKttvztyFOcmsF14bxEaSVv7iM4TxWEBn1rclmYHxDM4ow==",
+      "version": "1.20251109.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251109.0.tgz",
+      "integrity": "sha512-IGo/lzbYoeJdfLkpaKLoeG6C7Rwcf5kXjzV0wO8fLUSmlfOLQvXTIehWc7EkbHFHjPapDqYqR0KsmbizBi68Lg==",
       "cpu": [
         "x64"
       ],
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20251011.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251011.0.tgz",
-      "integrity": "sha512-gQpih+pbq3sP4uXltUeCSbPgZxTNp2gQd8639SaIbQMwgA6oJNHLhIART1fWy6DQACngiRzDVULA2x0ohmkGTQ==",
+      "version": "4.20251115.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251115.0.tgz",
+      "integrity": "sha512-aM7jp7IfKhqKvfSaK1IhVTbSzxB6KQ4gX8e/W29tOuZk+YHlYXuRd/bMm4hWkfd7B1HWNWdsx1GTaEUoZIuVsw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@poppinss/dumper": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.4.tgz",
-      "integrity": "sha512-iG0TIdqv8xJ3Lt9O8DrPRxw1MRLjNpoqiSGU03P/wNLP/s0ra0udPJ1J2Tx5M0J3H/cVyEgpbn8xUKRY9j59kQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1517,9 +1517,9 @@
       ]
     },
     "node_modules/@sindresorhus/is": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.0.tgz",
-      "integrity": "sha512-7F/yz2IphV39hiS2zB4QYVkivrptHHh0K8qJJd9HhuWSdvf8AN7NpebW3CcDZDBQsUPMoDKWsY2WWgW7bqOcfA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.1.tgz",
+      "integrity": "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1530,9 +1530,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.7.tgz",
-      "integrity": "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.12.tgz",
+      "integrity": "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1845,13 +1845,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1953,13 +1946,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/exsolve": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2069,9 +2055,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20251008.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251008.0.tgz",
-      "integrity": "sha512-sKCNYNzXG6l8qg0Oo7y8WcDKcpbgw0qwZsxNpdZilFTR4EavRow2TlcwuPSVN99jqAjhz0M4VXvTdSGdtJ2VfQ==",
+      "version": "4.20251109.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251109.0.tgz",
+      "integrity": "sha512-fm0J/IFrrx7RT1w3SIoDM5m7zPCa2wBtxBApy6G0QVjd2tx8w0WGlMFop6R49XyTfF1q3LRHCjFMfzJ8YS0RzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2083,7 +2069,7 @@
         "sharp": "^0.33.5",
         "stoppable": "1.1.0",
         "undici": "7.14.0",
-        "workerd": "1.20251008.0",
+        "workerd": "1.20251109.0",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10",
         "zod": "3.22.3"
@@ -2130,13 +2116,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2497,13 +2476,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
@@ -2522,17 +2494,13 @@
       "license": "MIT"
     },
     "node_modules/unenv": {
-      "version": "2.0.0-rc.21",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.21.tgz",
-      "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.7",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.6.1"
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/vite": {
@@ -2724,9 +2692,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20251008.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251008.0.tgz",
-      "integrity": "sha512-HwaJmXO3M1r4S8x2ea2vy8Rw/y/38HRQuK/gNDRQ7w9cJXn6xSl1sIIqKCffULSUjul3wV3I3Nd/GfbmsRReEA==",
+      "version": "1.20251109.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251109.0.tgz",
+      "integrity": "sha512-VfazMiymlzos0c1t9AhNi0w8gN9+ZbCVLdEE0VDOsI22WYa6yj+pYOhpZzI/mOzCGmk/o1eNjLMkfjWli6aRVg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2737,28 +2705,28 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20251008.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20251008.0",
-        "@cloudflare/workerd-linux-64": "1.20251008.0",
-        "@cloudflare/workerd-linux-arm64": "1.20251008.0",
-        "@cloudflare/workerd-windows-64": "1.20251008.0"
+        "@cloudflare/workerd-darwin-64": "1.20251109.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20251109.0",
+        "@cloudflare/workerd-linux-64": "1.20251109.0",
+        "@cloudflare/workerd-linux-arm64": "1.20251109.0",
+        "@cloudflare/workerd-windows-64": "1.20251109.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.43.0.tgz",
-      "integrity": "sha512-IBNqXlYHSUSCNNWj/tQN4hFiQy94l7fTxEnJWETXyW69+cjUyjQ7MfeoId3vIV9KBgY8y5M5uf2XulU95OikJg==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.47.0.tgz",
+      "integrity": "sha512-JP0U8oqUETK9D+ZbrSjFFOxGdufYsS6HsT0vLU1IAQrban9a6woMHdBZlGNn/lt8QA70xv1uFiJK8DUMPzC73A==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
-        "@cloudflare/unenv-preset": "2.7.7",
+        "@cloudflare/unenv-preset": "2.7.10",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.25.4",
-        "miniflare": "4.20251008.0",
+        "miniflare": "4.20251109.0",
         "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.21",
-        "workerd": "1.20251008.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20251109.0"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -2771,7 +2739,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20251008.0"
+        "@cloudflare/workers-types": "^4.20251109.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/package.json
+++ b/workers/package.json
@@ -24,6 +24,6 @@
     "tsx": "^4.11.0",
     "typescript": "^5.7.0",
     "vitest": "^3.2.4",
-    "wrangler": "^4.43.0"
+    "wrangler": "^4.47.0"
   }
 }


### PR DESCRIPTION
## Summary
- add zod-based schemas for manifest/start/next responses and integrate validation in datasource + manifest cache
- harden metrics client with payload sanitization, schema checks, and contract tests
- document FE runtime type guards in docs/issues/40 and add supporting unit tests

Closes #65

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit
