### PR TITLE
ci: add contract test gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,3 +43,41 @@ jobs:
           NEXT_DISABLE_DEVTOOLS: '1'
           NEXT_TELEMETRY_DISABLED: '1'
         run: npm run build
+
+  contract:
+    name: Contract Tests (Playwright + Vitest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run contract suite
+        env:
+          NEXT_PUBLIC_API_MOCK: '1'
+          NEXT_DISABLE_DEVTOOLS: '1'
+          NEXT_TELEMETRY_DISABLED: '1'
+        run: npm run contract
+
+      - name: Upload contract artifacts (failures)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-artifacts
+          path: web/test-results/contract-artifacts

--- a/docs/frontend/testing-notes.md
+++ b/docs/frontend/testing-notes.md
@@ -1,7 +1,7 @@
 # Frontend Testing Notes
 
 - Status: Draft
-- Last Updated: 2025-09-28 (web vitals instrumentation)
+- Last Updated: 2025-11-16 (contract tests + CI)
 
 ## この文書の目的
 フロントエンド開発者が、実装変更時にどのテストを実行し、どの観点を確認すべきかを素早く把握するためのメモです。`docs/quality/e2e-plan.md` で定義している公式な E2E 運用と補完関係にあり、より実務的な注意点や手動検証手順をまとめます。
@@ -44,7 +44,20 @@
 
 ---
 
-## 3. Playwright 実行メモ
+## 3. Contract Tests (API Guardrails)
+
+| コマンド | 用途 |
+| --- | --- |
+| `npm run contract` | 契約テストのフルスイート（Vitest + Playwright）。CI で必須チェック。 |
+| `npm run contract -- --filter <keyword>` | 特定のケースのみ実行（Vitest は `--filter`, Playwright は `--grep` にマッピング）。 |
+| `npm run contract:vitest` | 契約系 Vitest のみ（metrics/reveal シリアライズ）。 |
+| `npm run contract:pw` | Playwright/MSW を使った API 契約テストのみ。 |
+
+- Playwright 側は MSW が立ち上がるまで `/` へ遷移して待機しているので、ローカルでも API モックが取得できる。
+- 失敗時の JSON は `test-results/contract-artifacts/<timestamp>/` に保存され、CI では Actions Artifact としてダウンロード可能。
+- 追加ケースを書くときは `tests/contract/*.contract.spec.ts`（Playwright）か `tests/unit/*contract.spec.ts`（Vitest）に置く。
+
+## 4. Playwright 実行メモ
 
 | コマンド | 用途 |
 | --- | --- |
@@ -59,7 +72,7 @@
 
 ---
 
-## 4. 手動検証のポイント
+## 5. 手動検証のポイント
 
 | 観点 | 手順 | 補足 |
 | --- | --- | --- |
@@ -70,7 +83,7 @@
 
 ---
 
-## 5. ドキュメント更新の流れ
+## 6. ドキュメント更新の流れ
 
 1. 変更対象に関連する仕様ドキュメントを確認（例: `docs/frontend/play-flow.md`, `docs/product/embed-policy.md`）。
 2. 振る舞いを変更した場合は該当ドキュメントも同じ PR で更新。
@@ -79,7 +92,7 @@
 
 ---
 
-## 6. パフォーマンス計測メモ
+## 7. パフォーマンス計測メモ
 
 | 項目 | 手順 | 備考 |
 | --- | --- | --- |
@@ -99,7 +112,6 @@
 - `docs/frontend/play-flow.md` — `/play` の状態遷移と副作用
 - `docs/frontend/metrics-client.md` — メトリクス送信の仕組み
 - `docs/quality/a11y-play-result.md` — アクセシビリティ監査ログ
-- `docs/product/embed-policy.md` — 埋め込み/リンクのガイドライン
 - `docs/product/embed-policy.md` — 埋め込み/リンクのガイドライン
 
 > 更新の際は最終更新日 (`Last Updated`) を忘れずに書き換えてください。

--- a/web/package.json
+++ b/web/package.json
@@ -14,8 +14,8 @@
     "test:a11y": "playwright test tests/e2e/accessibility.spec.ts",
     "test:unit": "vitest run",
     "contract": "node ./scripts/run-contract.mjs",
-    "contract:pw": "playwright test -c playwright.contract.config.ts",
-    "contract:vitest": "vitest run tests/unit/metricsClient.contract.spec.ts tests/unit/reveal.contract.spec.ts",
+    "contract:pw": "node ./scripts/run-contract.mjs --pw-only",
+    "contract:vitest": "node ./scripts/run-contract.mjs --vitest-only",
     "test:lhci": "lhci autorun --config=./lighthouserc.json"
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,9 @@
     "test:e2e:ui": "playwright test --ui",
     "test:a11y": "playwright test tests/e2e/accessibility.spec.ts",
     "test:unit": "vitest run",
+    "contract": "node ./scripts/run-contract.mjs",
+    "contract:pw": "playwright test -c playwright.contract.config.ts",
+    "contract:vitest": "vitest run tests/unit/metricsClient.contract.spec.ts tests/unit/reveal.contract.spec.ts",
     "test:lhci": "lhci autorun --config=./lighthouserc.json"
   },
   "dependencies": {

--- a/web/playwright.contract.config.ts
+++ b/web/playwright.contract.config.ts
@@ -1,0 +1,34 @@
+import path from 'node:path'
+import { defineConfig } from '@playwright/test'
+
+const runStamp = new Date().toISOString().replace(/[:.]/g, '-')
+
+export default defineConfig({
+  testDir: './tests/contract',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  outputDir: path.join('test-results', 'contract-artifacts', runStamp),
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000',
+    headless: true,
+    channel: 'chrome',
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
+  },
+  webServer: process.env.PLAYWRIGHT_WEB_SERVER
+    ? undefined
+    : {
+        command: 'npm run dev',
+        cwd: './',
+        env: {
+          NEXT_PUBLIC_API_MOCK: '1',
+          NEXT_PUBLIC_PLAY_AUTOSTART: '0',
+          NEXT_DISABLE_DEVTOOLS: '1',
+          NEXT_TELEMETRY_DISABLED: '1',
+        },
+        port: 3000,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+})

--- a/web/playwright.contract.config.ts
+++ b/web/playwright.contract.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000',
     headless: true,
-    channel: 'chrome',
+    channel: 'chromium',
     trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
   },
   webServer: process.env.PLAYWRIGHT_WEB_SERVER

--- a/web/scripts/run-contract.mjs
+++ b/web/scripts/run-contract.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function run(command, args) {
+  const result = spawnSync('npx', [command, ...args], {
+    stdio: 'inherit',
+    env: { ...process.env, NODE_ENV: process.env.NODE_ENV ?? 'test' },
+  })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+function collectContractTests(rootDir) {
+  const entries = readdirSync(rootDir, { withFileTypes: true })
+  const files = []
+  for (const entry of entries) {
+    const fullPath = join(rootDir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectContractTests(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.contract.spec.ts')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const projectRoot = dirname(scriptDir)
+const unitTestDir = join(projectRoot, 'tests', 'unit')
+
+const unitContractTests = collectContractTests(unitTestDir).map((abs) =>
+  relative(projectRoot, abs),
+)
+
+const argv = process.argv.slice(2)
+let filter
+const passthrough = []
+
+for (let i = 0; i < argv.length; i += 1) {
+  const arg = argv[i]
+  if (arg === '--filter' && argv[i + 1]) {
+    filter = argv[i + 1]
+    i += 1
+  } else {
+    passthrough.push(arg)
+  }
+}
+
+const vitestArgs = ['run', ...unitContractTests]
+if (filter) vitestArgs.push('--filter', filter)
+vitestArgs.push(...passthrough)
+run('vitest', vitestArgs)
+
+const playwrightArgs = ['test', '-c', 'playwright.contract.config.ts']
+if (filter) playwrightArgs.push('--grep', filter)
+playwrightArgs.push(...passthrough)
+run('playwright', playwrightArgs)

--- a/web/src/features/quiz/datasource.ts
+++ b/web/src/features/quiz/datasource.ts
@@ -4,7 +4,7 @@
 import type { RoundStartRequest, Manifest } from './api/manifest';
 import type { Phase1StartResponse, Phase1NextResponse } from './api/types';
 import { ApiError, ensureApiError, delay, isNavigatorOffline } from './api/errors';
-import { Phase1StartResponseSchema, Phase1NextResponseSchema, ManifestSchema } from './api/schemas';
+import { Phase1StartResponseSchema, Phase1NextResponseSchema, ManifestSchema, ensureApiResponse } from './api/schemas';
 import type { ZodType } from 'zod';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '';
@@ -99,15 +99,7 @@ async function fetchJson<T>(path: string, options: RequestOptions<T>): Promise<T
       }
 
       if (schema) {
-        const validated = schema.safeParse(parsed);
-        if (!validated.success) {
-          throw new ApiError('decode', 'Unexpected response shape from server', {
-            cause: validated.error,
-            details: validated.error.format(),
-            retryable: false,
-          });
-        }
-        return validated.data;
+        return ensureApiResponse(parsed, schema);
       }
 
       return parsed as T;

--- a/web/tests/contract/rounds.contract.spec.ts
+++ b/web/tests/contract/rounds.contract.spec.ts
@@ -1,0 +1,80 @@
+import type { Page, TestInfo } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { Phase1NextResponseSchema, Phase1StartResponseSchema } from '@/src/features/quiz/api/schemas'
+
+async function waitForMswReady(page: Page) {
+  await page.goto('/')
+  await page.waitForFunction(() => (window as { __MSW_READY__?: boolean }).__MSW_READY__ === true, {
+    timeout: 5000,
+  })
+}
+
+async function attachJson(testInfo: TestInfo, name: string, data: unknown) {
+  await testInfo.attach(`${name}.json`, {
+    body: JSON.stringify(data, null, 2),
+    contentType: 'application/json',
+  })
+}
+
+test.describe('contract: rounds API', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForMswReady(page)
+  })
+
+  test('POST /v1/rounds/start responds with round + question payload', async ({ page }, testInfo) => {
+    const response = await page.evaluate(async () => {
+      const res = await fetch('/v1/rounds/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          total: 5,
+          filters: { difficulty: ['normal'], era: ['90s'] },
+        }),
+      })
+      const body = await res.json()
+      return { status: res.status, body }
+    })
+
+    await attachJson(testInfo, 'rounds-start', response.body)
+
+    expect(response.status).toBe(200)
+    const parsed = Phase1StartResponseSchema.parse(response.body)
+    expect(parsed.question.title).toBeTruthy()
+    expect(parsed.choices.length).toBeGreaterThan(0)
+    expect(parsed.round?.progress.total).toBeGreaterThan(0)
+  })
+
+  test('POST /v1/rounds/next emits reveal payload that matches schema', async ({ page }, testInfo) => {
+    const start = await page.evaluate(async () => {
+      const res = await fetch('/v1/rounds/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ total: 3 }),
+      })
+      const body = await res.json()
+      return { status: res.status, body }
+    })
+
+    await attachJson(testInfo, 'rounds-start-for-next', start.body)
+    expect(start.status).toBe(200)
+    const parsedStart = Phase1StartResponseSchema.parse(start.body)
+
+    const answer = parsedStart.choices[0]?.id ?? 'a'
+    const next = await page.evaluate(async ({ token, answerId }) => {
+      const res = await fetch('/v1/rounds/next', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ continuationToken: token, answer: answerId }),
+      })
+      const body = await res.json()
+      return { status: res.status, body }
+    }, { token: parsedStart.continuationToken, answerId: answer })
+
+    await attachJson(testInfo, 'rounds-next', next.body)
+
+    expect(next.status).toBe(200)
+    const parsedNext = Phase1NextResponseSchema.parse(next.body)
+    expect(parsedNext.result.reveal.title).toBeTruthy()
+    expect(parsedNext.result.reveal.game).toBeTruthy()
+  })
+})

--- a/web/tests/unit/metricsClient.contract.spec.ts
+++ b/web/tests/unit/metricsClient.contract.spec.ts
@@ -131,4 +131,20 @@ describe('metricsClient contract', () => {
 
     expect(getQueue()).toHaveLength(0);
   });
+
+  it('rejects batch payloads that fall outside the shared schema', () => {
+    expect(() =>
+      MetricsBatchSchema.parse({
+        client: { client_id: '' },
+        events: [
+          {
+            id: 'evt-1',
+            name: 'invalid_event',
+            ts: '2024-01-01T00:00:00.000Z',
+            attrs: {},
+          },
+        ],
+      }),
+    ).toThrow();
+  });
 });

--- a/web/tests/unit/reveal.contract.spec.ts
+++ b/web/tests/unit/reveal.contract.spec.ts
@@ -99,4 +99,12 @@ describe('reveal contracts', () => {
     expect(validatedLast.links?.[1]).toMatchObject({ provider: 'spotify' });
     expect(validatedLast.meta).toMatchObject({ workTitle: 'Battle Theme', composer: 'N. Uematsu' });
   });
+
+  it('flags unsupported providers in reveal payload', () => {
+    expect(() =>
+      RevealSchema.parse({
+        links: [{ provider: 'invalid', url: 'https://example.com' }],
+      }),
+    ).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary\n- add shared ensureApiResponse guard for quiz API responses\n- introduce contract test suite (Playwright+MSW + Vitest) and CLI runner\n- add CI contract job with artifacts and update docs\n\nCloses #135\n\n## Testing\n- npm run contract:vitest\n- npm run contract:pw