### PR TITLE
Ops: Web vitals and quiz perf marks (#75)

### DIFF
--- a/web/app/play/page.tsx
+++ b/web/app/play/page.tsx
@@ -73,6 +73,10 @@ function PlayPageContent() {
   const isMountedRef = React.useRef(true);
   React.useEffect(() => () => { isMountedRef.current = false; }, []);
 
+  React.useEffect(() => {
+    mark('quiz:autostart-ready', { auto: queryAutoStartValue });
+  }, [queryAutoStartValue]);
+
   const [toast, setToast] = React.useState<ToastState | null>(null);
   const pendingRetryRef = React.useRef<(() => void) | null>(null);
   const activeFiltersRef = React.useRef<Partial<RoundStartRequest> | undefined>(undefined);
@@ -222,10 +226,14 @@ function PlayPageContent() {
         },
       });
       mark('quiz:first-question-visible', { questionId: question.id });
+      measure('quiz:autostart-to-first-question', 'quiz:autostart-ready', 'quiz:first-question-visible', {
+        auto: queryAutoStartValue,
+        questionId: question.id,
+      });
       measure('quiz:navigation-to-first-question', 'navigationStart', 'quiz:first-question-visible');
       pendingRetryRef.current = null;
       closeToast();
-    } catch (e: unknown) {
+      } catch (e: unknown) {
       if (!isMountedRef.current) return;
       const apiError = ensureApiError(e);
       let errorMessage = mapApiErrorToMessage(apiError);
@@ -239,7 +247,7 @@ function PlayPageContent() {
       });
     }
     },
-    [safeDispatch, closeToast, scheduleRetry, t],
+    [safeDispatch, closeToast, scheduleRetry, t, queryAutoStartValue],
   );
 
   // bootstrap (autostart mode)

--- a/web/app/reportWebVitals.ts
+++ b/web/app/reportWebVitals.ts
@@ -1,13 +1,34 @@
-import type { NextWebVitalsMetric } from 'next/dist/shared/lib/utils';
+import type { NextWebVitalsMetric } from 'next/dist/shared/lib/utils'
+
+const isDev = process.env.NODE_ENV !== 'production'
+const VITALS_EVENT_NAME = 'vgm:vitals'
+
+function emitCustomHandler(metric: NextWebVitalsMetric) {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return
+  try {
+    const event = new CustomEvent(VITALS_EVENT_NAME, { detail: metric })
+    window.dispatchEvent(event)
+  } catch {
+    // In some environments CustomEvent might be blocked or not fully supported; ignore and fall back to console
+  }
+}
+
+function logToConsole(metric: NextWebVitalsMetric) {
+  if (!isDev || typeof console === 'undefined' || typeof console.info !== 'function') return
+  const rounded = metric.name === 'CLS'
+    ? Math.round(metric.value * 1000) / 1000
+    : Math.round(metric.value)
+  console.info('[vitals]', metric.name, rounded, metric)
+}
 
 export function reportWebVitals(metric: NextWebVitalsMetric): void {
-  if (typeof window === 'undefined') return;
-  const store = (window as unknown as { __VITALS__?: NextWebVitalsMetric[] }).__VITALS__ ?? [];
-  store.push(metric);
-  (window as unknown as { __VITALS__?: NextWebVitalsMetric[] }).__VITALS__ = store;
-
-  if (process.env.NODE_ENV !== 'production') {
-    const rounded = Math.round(metric.value * 100) / 100;
-    console.info('[vitals]', metric.name, rounded, metric);
+  if (typeof window === 'undefined') return
+  const vitalsStore = window as unknown as { __VITALS__?: NextWebVitalsMetric[] }
+  if (!Array.isArray(vitalsStore.__VITALS__)) {
+    vitalsStore.__VITALS__ = []
   }
+  vitalsStore.__VITALS__!.push(metric)
+
+  emitCustomHandler(metric)
+  logToConsole(metric)
 }


### PR DESCRIPTION
## Summary
- emit Core Web Vitals via CustomEvent and console-friendly rounding
- add quiz autostart/reveal performance marks and measures for key flow
- document baselines and collection steps in testing notes

## Testing
- npm run lint
- npm run typecheck
