### PR TITLE
CI: Lighthouse smoke for key routes (#76)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,6 +11,11 @@ jobs:
     defaults:
       run:
         working-directory: web
+    env:
+      NEXT_DISABLE_DEVTOOLS: '1'
+      NEXT_TELEMETRY_DISABLED: '1'
+      NEXT_PUBLIC_API_MOCK: '1'
+      NEXT_PUBLIC_PLAY_AUTOSTART: '1'
     steps:
       - uses: actions/checkout@v4
 
@@ -23,12 +28,7 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Build static export
-        env:
-          NEXT_DISABLE_DEVTOOLS: '1'
-          NEXT_TELEMETRY_DISABLED: '1'
-          NEXT_PUBLIC_API_MOCK: '1'
-          NEXT_PUBLIC_PLAY_AUTOSTART: '1'
+      - name: Build app
         run: npm run build
 
       - name: Run Lighthouse CI

--- a/docs/frontend/testing-notes.md
+++ b/docs/frontend/testing-notes.md
@@ -129,14 +129,13 @@
   - Performance >= 0.80
   - Accessibility >= 0.95
   - Best Practices / SEO >= 0.90
-- ローカル手順（モック API 前提）
+- ローカル手順（モック API 前提、静的書き出し）
   ```bash
   cd web
-  NEXT_PUBLIC_API_MOCK=1 NEXT_PUBLIC_PLAY_AUTOSTART=1 npm run build
-  npm run test:lhci
+  NEXT_PUBLIC_API_MOCK=1 NEXT_PUBLIC_PLAY_AUTOSTART=1 npm run build  # out/ を生成
+  npm run test:lhci                                            # out/ を直接走査
   ls lighthouse-report  # HTML/JSON レポート
   ```
-  ※ `lighthouserc.json` の `startServerCommand` で `npm run start` を自動起動するため、別途 `serve` は不要。
 
 ---
 

--- a/docs/frontend/testing-notes.md
+++ b/docs/frontend/testing-notes.md
@@ -122,6 +122,22 @@
 
 ※ Lighthouse CI ワークフロー (#76) が入れば、これらを CI で自動収集する予定。
 
+### 7.4 Lighthouse CI の回し方（CI/ローカル）
+
+- CI: `.github/workflows/lighthouse.yml` が PR / main push で走り、`web/lighthouse-report` を artifact 化。
+- しきい値（失敗条件）
+  - Performance >= 0.80
+  - Accessibility >= 0.95
+  - Best Practices / SEO >= 0.90
+- ローカル手順（モック API 前提）
+  ```bash
+  cd web
+  NEXT_PUBLIC_API_MOCK=1 NEXT_PUBLIC_PLAY_AUTOSTART=1 npm run build
+  npm run test:lhci
+  ls lighthouse-report  # HTML/JSON レポート
+  ```
+  ※ `lighthouserc.json` の `startServerCommand` で `npm run start` を自動起動するため、別途 `serve` は不要。
+
 ---
 
 ## 参考リンク

--- a/web/lighthouserc.json
+++ b/web/lighthouserc.json
@@ -1,14 +1,8 @@
 {
   "ci": {
     "collect": {
-      "startServerCommand": "NEXT_PUBLIC_API_MOCK=1 NEXT_PUBLIC_PLAY_AUTOSTART=1 npm run start -- --hostname 0.0.0.0 --port 3000",
-      "startServerReadyPattern": "started server",
-      "startServerReadyTimeout": 120000,
-      "url": [
-        "http://localhost:3000/",
-        "http://localhost:3000/play",
-        "http://localhost:3000/result"
-      ],
+      "staticDistDir": "./out",
+      "url": ["./index.html", "./play.html", "./result.html"],
       "numberOfRuns": 1,
       "settings": {
         "preset": "desktop",

--- a/web/lighthouserc.json
+++ b/web/lighthouserc.json
@@ -1,9 +1,15 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./out",
-      "url": ["./index.html", "./play.html", "./result.html"],
-      "numberOfRuns": 3,
+      "startServerCommand": "NEXT_PUBLIC_API_MOCK=1 NEXT_PUBLIC_PLAY_AUTOSTART=1 npm run start -- --hostname 0.0.0.0 --port 3000",
+      "startServerReadyPattern": "started server",
+      "startServerReadyTimeout": 120000,
+      "url": [
+        "http://localhost:3000/",
+        "http://localhost:3000/play",
+        "http://localhost:3000/result"
+      ],
+      "numberOfRuns": 1,
       "settings": {
         "preset": "desktop",
         "throttlingMethod": "devtools",
@@ -13,10 +19,10 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:performance": ["error", { "minScore": 0.8 }],
         "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:best-practices": ["warn", { "minScore": 0.9 }],
-        "categories:seo": ["warn", { "minScore": 0.9 }]
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
       }
     },
     "upload": {


### PR DESCRIPTION
## Summary
- switch LHCI to run against live Next server with MSW mocks for /, /play, /result
- enforce category thresholds (perf 0.80, a11y 0.95, best-practices/seo 0.90) to fail workflow
- upload reports as artifacts and document local lhci usage/thresholds

## Testing
- npm run lint
- npm run typecheck
