### PR TITLE
docs: finalize phase 3C runbooks and metrics

### DIFF
--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -1,7 +1,7 @@
 # プロダクトロードマップ — vgm-quiz
 
 - **Status**: Living Document
-- **Last Updated**: 2025-11-15
+- **Last Updated**: 2025-11-16
 - **目的**: プロジェクトの各フェーズにおける機能実装を追跡
 
 ---
@@ -96,21 +96,21 @@
 
 **ゴール**: 完全自動クイズ生成へ進む前に、現行フィルタ配信を計測・監視可能にし、失敗時でも即復旧できる体制を築く。手動介入ゼロで安定運用できる仕組みを整備する。
 
-**ステータス**: 計画中（2025-11-15 時点）
+**ステータス**: Phase 3A/3B 完了、3C/3D 計画中（2025-11-16 時点）
 
 **開始予定**: Phase 2 安定確認後すぐ（2025-11 下旬見込み）
 
 ### サブフェーズ別の状況と担当Issue
 
-#### Phase 3A - 観測性基盤（計画中）
-- [ ] #75 Ops: Web Vitals & custom performance marks（P2, area:ops）
-- [ ] #76 Ops: CI Lighthouse smoke tests（P2, area:ops）
-- [ ] #134 OPS-03: Observability dashboard & Slack alerts（P2, area:ops）
+#### Phase 3A - 観測性基盤（完了 ✅）
+- ✅ #75 Ops: Web Vitals & custom performance marks（P2, area:ops、2025-11-16 クローズ）
+- ✅ #76 Ops: CI Lighthouse smoke tests（P2, area:ops、2025-11-16 クローズ）
+- ✅ #134 OPS-03: Observability dashboard & Slack alerts（P2, area:ops、2025-11-16 クローズ）
 
-#### Phase 3B - Guardrails（計画中）
-- [ ] #65 FE: Runtime type guards for API responses（P1, area:fe）
-- [ ] #77 FE: Contract tests for metrics/reveal payloads（P2, area:fe）
-- [ ] #135 FE-Guardrails: Enforce contract tests in CI（P2, area:fe）
+#### Phase 3B - Guardrails（完了 ✅）
+- ✅ #65 FE: Runtime type guards for API responses（P1, area:fe、2025-11-16 クローズ）
+- ✅ #77 FE: Contract tests for metrics/reveal payloads（P2, area:fe、2025-11-16 クローズ）
+- ✅ #135 FE-Guardrails: Enforce contract tests in CI（P2, area:fe、2025-11-16 クローズ）
 
 #### Phase 3C - Runbook & Metrics Docs（計画中）
 - [ ] #32 DOCS-01: quality/metrics.md（P2, area:docs）
@@ -194,6 +194,7 @@
 ## 変更履歴
 
 - **2025-11-11**: Phase 2C 完了（#113, #114, #118 マージ、全3タスク完了）、Phase 2D 開始（#115 QA-01取組開始）
+- **2025-11-16**: Phase 3A/3B 完了 (#75, #76, #134, #65, #77, #135 クローズ)。Phase 3C/3D 計画中に更新。
 - **2025-11-02**: Phase 2B 完了（#28 API-02 マージ、全4タスク完了）、Phase 2C 開始準備
 - **2025-10-22**: Phase 2A 完了状況と Phase 2B〜2D の担当 Issue を更新、成功基準を現行バックログと整合
 - **2025-10-13**: 初回ロードマップ作成、Phase 1完了マーク、Phase 2計画開始

--- a/docs/ops/api-security-operations.md
+++ b/docs/ops/api-security-operations.md
@@ -1,0 +1,317 @@
+# API 安全運用メモ: レート制限・署名鍵ローテーション (Phase 3C)
+
+**ステータス**: Phase 3C 初版（暫定手順）
+**対象バージョン**: Phase 2B 以降
+**最終更新**: 2025-11-16
+**優先度**: P3（Phase 3D/4 での実装予定）
+
+---
+
+## 目的
+
+ステートレス API（`/v1/rounds/start`, `/v1/rounds/next`）の安全な運用を確保するために、レート制限と JWS 署名鍵ローテーションの手順を明文化する。現段階では暫定手順であり、本番規模のトラフィックに応じて調整される。
+
+---
+
+## 現行の API セキュリティ体制
+
+### Token 構造
+
+- **フォーマット**: JWS (JSON Web Signature) with HMAC-SHA256
+- **TTL**: 120 秒（デフォルト）
+- **署名方式**: `HMAC-SHA256(header.payload, secret)`
+- **検証**: Signature + Expiration チェック
+
+**Token 例**
+```
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyaWQiOiI1NTBlODQwMC1lMjliLTQxZDQtYTcxNi00NDY2NTU0NDAwMDAiLCJpZHgiOjAsInRvdGFsIjoxMCwic2VlZCI6ImJhc2U2NHVybCIsImZpbHRlcnNIYXNoIjoiYWJjZGVmMDEiLCJmaWx0ZXJzS2V5Ijoie30iLCJ2ZXIiOjEsImlhdCI6MTczMDc0NzIwMCwiZXhwIjoxNzMwNzQ3MzIwfQ.signature_bytes_base64url
+```
+
+**署名鍵保存場所**
+- **開発環境**: `workers/api/wrangler.toml` で `JWT_SECRET` にハードコード（プレースホルダ値）
+- **本番環境**: Cloudflare Workers Secrets へ設定（環境変数 `JWT_SECRET`）
+
+---
+
+## レート制限（計画中 - Phase 3D/4）
+
+### 現状
+
+**実装状況**: なし。今後 Cloudflare Rate Limiting や Durable Objects で追加予定。
+
+### 計画案
+
+#### エンドポイント別の制限
+
+| エンドポイント | 制限対象 | 制限値（案） | 理由 |
+|--------------|--------|----------|------|
+| `POST /v1/rounds/start` | clientId あたり | 1 req/sec | クイズ開始は連続呼び出しされないはず |
+| `POST /v1/rounds/next` | token（roundId）あたり | 10 req/min | 回答提出の連続呼び出しを防止 |
+| `POST /v1/metrics` | clientId あたり | 100 req/min | メトリクス送信のバッチ化を想定 |
+| `GET /v1/manifest` | clientId あたり | 1 req/min | キャッシュがあるため頻繁なポール防止 |
+
+#### 実装の流れ（仮）
+
+1. **Phase 3D**: Cloudflare Rate Limiting API を使用した基本実装
+2. **Phase 4A**: トラフィック観測データを元に数値最適化
+3. **Phase 4B**: Durable Objects で分散レート制限状態管理（オプション）
+
+#### 監視とアラート
+
+- 制限超過時の応答: HTTP 429 Too Many Requests
+- ログ: 制限超過イベントをメトリクス `rate_limit_exceeded` として記録
+- アラート: 日次超過数 > 100 で Slack #vgm-ops に通知
+
+---
+
+## JWS 署名鍵ローテーション手順
+
+### 概要
+
+ステートレス API では、**署名鍵を変更すると既存の有効な token が検証失敗**になる可能性がある。したがって、「猶予期間を設けて段階的に新鍵へ移行」する手順が必要。
+
+### ローテーション戦略
+
+**デュアルキー方式**（推奨）：
+1. **Phase 1**: 新鍵を `JWT_SECRET_NEW` として並行配置
+2. **Phase 2**: API で新鍵・旧鍵の両方で検証を試みる
+3. **Phase 3**: 猶予期間（24～48h）でフロントエンドが新 token を取得
+4. **Phase 4**: 旧鍵を廃棄、新鍵を `JWT_SECRET` に昇格
+
+**実装上の注意**: Cloudflare Workers では複数環境変数を持つ場合、以下のように対応：
+
+```typescript
+// workers/shared/lib/token.ts 修正例
+export async function verifyJWSTokenDualKey(
+  token: string,
+  secretPrimary: string,
+  secretSecondary?: string,
+): Promise<Phase2TokenPayload | null> {
+  // 新鍵で試す
+  let payload = await verifyJWSToken(token, secretPrimary);
+
+  // 新鍵失敗 + 旧鍵あれば、旧鍵で試す（猶予期間用）
+  if (!payload && secretSecondary) {
+    payload = await verifyJWSToken(token, secretSecondary);
+  }
+
+  return payload;
+}
+```
+
+### ローテーション実施手順
+
+#### 事前準備（本番対応の前日）
+
+1. **新鍵生成**
+   ```bash
+   # 強力なランダム文字列を生成（64 文字以上推奨）
+   openssl rand -hex 32
+   # または
+   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+   ```
+   出力例: `a3f5e8c2b1d7f9a4c6e2b8d1f3a5e7c9b0d2f4a6c8e0b2d4f6a8c0e2b4d6f8`
+
+2. **テスト実施**
+   ```bash
+   # ローカルで新旧鍵の両方でテスト
+   cd workers
+   JWT_SECRET="[新鍵]" JWT_SECRET_NEW="[新鍵]" npm run test
+   ```
+
+3. **ステージング環境でのテスト**
+   ```bash
+   # ステージング環境に新鍵を試験的に配置
+   wrangler secret put JWT_SECRET_NEW --env staging
+   # API デプロイ（dual-key 検証コード有効）
+   wrangler deploy --env staging
+   ```
+
+#### Phase 1: 新鍵を並行配置（猶予期間開始）
+
+1. **Cloudflare ダッシュボードで新鍵を設定**
+   ```bash
+   wrangler secret put JWT_SECRET_NEW
+   # プロンプトで新鍵の値を貼り付け
+   ```
+
+2. **API コードを dual-key 検証に更新**
+   - `workers/api/src/routes/rounds.ts` の token 検証部分を修正
+   - `verifyJWSTokenDualKey()` を使用（新鍵 → 旧鍵の順）
+
+3. **ステージングで動作確認**
+   ```bash
+   npm run dev:api  # ローカルで dual-key 検証が機能することを確認
+   ```
+
+4. **本番にデプロイ**
+   ```bash
+   npm run deploy:api
+   # ※ この時点で API は新旧両方の鍵で token を受け付ける
+   ```
+
+5. **フロントエンド側の新 token 取得確認**
+   - Grafana で `/v1/rounds/start` レスポンスの token を監視
+   - ※ ローテーション直後、既存 token は旧鍵でも有効なため、新 token は段階的に増える
+
+#### Phase 2: 旧鍵を廃棄・新鍵を昇格（猶予期間終了）
+
+**実施タイミング**: 新鍵導入後 24～48h
+
+1. **旧鍵の利用率確認**
+   ```sql
+   -- Grafana/Loki で確認（イベントログから）
+   count by (token_signed_with) (api_request_success)
+   -- 旧鍵の割合が 5% 以下なら廃棄 OK
+   ```
+
+2. **API コードを新鍵単一キーに更新**
+   - `verifyJWSToken()` で新鍵のみ使用するコードに戻す
+   - 旧鍵検証ロジックを削除
+
+3. **テスト**
+   ```bash
+   JWT_SECRET="[新鍵]" npm run test
+   ```
+
+4. **本番にデプロイ**
+   ```bash
+   npm run deploy:api
+   # ※ この時点で新鍵のみが有効
+   ```
+
+5. **旧鍵削除**
+   ```bash
+   wrangler secret delete JWT_SECRET_NEW
+   # ※ 念のため、24h 後に実施
+   ```
+
+#### Phase 3: 事後対応（トラブル時）
+
+**シナリオ 1: 古い token がまだ多く使用されている場合**
+- 猶予期間を延長（48h → 72h）
+- フロントエンド側でキャッシュが古い token を返していないか確認
+
+**シナリオ 2: 旧鍵廃棄後に検証エラーが急増**
+- ロールバック: `JWT_SECRET` を旧鍵に戻す
+- 原因調査: キャッシュされた古い token がまだ利用されていないか確認
+
+### ローテーション時の監視メトリクス
+
+| メトリクス | 監視対象 | アラート条件 |
+|-----------|---------|-----------|
+| `token_verification_failures` | 検証エラー数 | 日次 > 10 or 率 > 1% |
+| `token_age_distribution` | Token の生成時刻 | 旧鍵の token 率 > 20% (猶予期間内), 0% (猶予期間後) |
+| `api_request_latency` | API レスポンス時間 | p99 > 500ms（検証処理の遅延を検知） |
+
+---
+
+## 鍵管理のベストプラクティス
+
+### 一般的な注意事項
+
+1. **鍵の保管**
+   - Cloudflare Workers Secrets で管理（環境変数経由）
+   - ローカルファイルにハードコードしない
+   - Git にコミットしない
+
+2. **鍵の寿命**
+   - 計画的なローテーション: 3～6 ヶ月ごと推奨
+   - 緊急時: セキュリティ侵害疑いの場合は即座にローテーション
+
+3. **ローテーション時の通知**
+   - Slack #vgm-ops に「鍵ローテーション予定」を 1 日前に通知
+   - ローテーション完了後、監視メトリクスのスクリーンショットを共有
+
+4. **バックアップ/復旧**
+   - ローテーション前に旧鍵のバックアップを Vault/Secret Manager に保管
+   - 万一廃棄した旧鍵が必要になった場合に復旧可能に
+
+---
+
+## テストとシミュレーション
+
+### ローカルテスト
+
+1. **Dual-Key 検証のテスト**
+   ```bash
+   cd workers
+
+   # 新旧両鍵でテスト
+   JWT_SECRET_NEW="new-secret" JWT_SECRET="old-secret" npm run test -- token.spec.ts
+   ```
+
+2. **Token TTL テスト**
+   ```bash
+   # 120秒後の検証失敗を確認
+   npm run test -- token.spec.ts -- --timeout 130000
+   ```
+
+### ステージング環境でのテスト
+
+1. **ローテーション前シミュレーション**
+   - ステージング環境で新鍵を導入
+   - `/v1/rounds/start` → `/v1/rounds/next` フロー全体をテスト
+   - Playwright E2E で token 更新フローを検証
+   ```bash
+   cd web
+   npm run test:e2e -- --grep "token rotation"  # テスト名で filter
+   ```
+
+2. **メトリクス確認**
+   - Grafana で token 検証成功率が 100% を維持しているか確認
+
+---
+
+## 関連ドキュメント・リソース
+
+- [api/rounds-token-spec.md](../api/rounds-token-spec.md) - JWS token 仕様詳細
+- [workers/shared/lib/token.ts](../../workers/shared/lib/token.ts) - Token 生成・検証実装
+- [workers/api/src/routes/rounds.ts](../../workers/api/src/routes/rounds.ts) - Token 使用箇所
+- [Cloudflare Workers Secrets 管理](https://developers.cloudflare.com/workers/platform/bindings/environment-variables/) - 環境変数管理ガイド
+- [ops/observability.md](observability.md) - モニタリング・アラート設定
+
+---
+
+## 実装ロードマップ
+
+### Phase 3C（現在）
+- ✅ 鍵ローテーション手順書（このドキュメント）
+- ✅ Dual-key 検証の設計
+
+### Phase 3D
+- [ ] Dual-key 検証コード実装・テスト
+- [ ] ステージング環境でローテーション試行
+
+### Phase 4A
+- [ ] 本番環境での初回鍵ローテーション実施
+- [ ] メトリクス監視・アラート設定
+- [ ] 運用手順の改善
+
+### Phase 4B (Optional)
+- [ ] Cloudflare Rate Limiting API の統合
+- [ ] レート制限メトリクスの集計・アラート
+
+---
+
+## トラブルシューティング
+
+### よくある問題
+
+**Q1: Token 検証エラーが突然増加した**
+- A: 鍵の設定ミス（タイポ、不完全なコピー）を確認。Cloudflare dashboard で `JWT_SECRET` が正確か確認。
+
+**Q2: ローテーション後、クライアント側が旧 token を返し続ける**
+- A: localStorage キャッシュを確認。`vgm2.session.token` が残っていないか確認し、クライアント側で強制更新。
+
+**Q3: Dual-key 検証の実装後、レスポンス遅延が増加**
+- A: 暗号化計算量削減。新鍵での検証失敗時に旧鍵を試すため、新鍵を優先順位高く設定（実装時に注意）。
+
+---
+
+## 変更履歴
+
+- **2025-11-16**: Phase 3C 初版作成（Issue #37）
+  - レート制限の計画案を追加
+  - JWS 署名鍵ローテーション手順を記載
+  - テスト・監視メトリクスを定義

--- a/docs/ops/api-security-operations.md
+++ b/docs/ops/api-security-operations.md
@@ -119,13 +119,9 @@ export async function verifyJWSTokenDualKey(
    JWT_SECRET="[新鍵]" JWT_SECRET_NEW="[新鍵]" npm run test
    ```
 
-3. **ステージング環境でのテスト**
-   ```bash
-   # ステージング環境に新鍵を試験的に配置
-   wrangler secret put JWT_SECRET_NEW --env staging
-   # API デプロイ（dual-key 検証コード有効）
-   wrangler deploy --env staging
-   ```
+3. **検証環境でのテスト（任意）**
+   - リポジトリの `wrangler.toml` には単一環境のみ定義されているため、デフォルトでは `wrangler secret put JWT_SECRET_NEW` → `wrangler deploy` でそのまま検証する。
+   - チームで追加の Cloudflare Workers 環境（例: staging）を用意している場合のみ、`--env <environment>` を付与して同じ手順を実施する。
 
 #### Phase 1: 新鍵を並行配置（猶予期間開始）
 

--- a/docs/ops/runbooks/audio-playback.md
+++ b/docs/ops/runbooks/audio-playback.md
@@ -1,0 +1,264 @@
+# Runbook: 音声埋め込み失敗の初動対応
+
+**ステータス**: Phase 3C 初版
+**対象バージョン**: Phase 2B 以降
+**最終更新**: 2025-11-16
+
+---
+
+## 目的
+
+YouTube 埋め込みプレイヤーが表示されず、ユーザーがリンク経由で外部サービスへ遷移する頻度の増加を検知し、原因を特定・対応する。
+
+---
+
+## 検知と監視
+
+### メトリクスキー
+
+Reveal Card で以下のイベントを記録：
+
+| イベント | 発火条件 | 属性 | 含意 |
+|---------|---------|------|------|
+| `embed_fallback_to_link` | インライン再生有効 + URL が YouTube 形式に変換できない | `reason: "no_embed_available"`, `provider: "youtube"`, `questionId` | ソースデータの URL が不正またはプロバイダが YouTube 以外 |
+| `embed_error` | iframe src が設定されたが iframe.onError が発火 | `reason: "load_error"`, `provider: "youtube"`, `questionId` | YouTube 動画が削除/非公開/年齢制限/地域制限など |
+| `reveal_open_external` | ユーザーが「Open in X」リンククリック | `provider: "youtube"` | ユーザーが外部サービスへ遷移（埋め込み成功/失敗問わず） |
+
+### ダッシュボード・アラートの設定例
+
+1. **Embed Fallback Rate** (`embed_fallback_to_link` / `reveal_view`)
+   - 目標: < 5% per day
+   - しきい値: 5% 以上で Slack #vgm-ops に注意通知
+   - アクション: データ品質チェック（URL 修正が必要か確認）
+
+2. **Embed Load Error Rate** (`embed_error` / `embed_attempt`)
+   - 目標: < 2% per day
+   - しきい値: 3% 以上で Slack #vgm-ops に警告通知
+   - アクション: YouTube 動画の可用性確認（削除/制限）
+
+3. **External Open Rate** (`reveal_open_external` / `reveal_view`)
+   - 参考指標（必ずしも問題ではない）
+   - > 80% が外部へ遷移している場合: インライン再生設定の確認
+
+---
+
+## 原因の切り分け
+
+### シナリオ 1: embed_fallback_to_link が多発
+
+**症状**
+- ダッシュボードで `embed_fallback_to_link` の割合が 5% を超えている
+- YouTube 埋め込みが一切表示されない
+
+**調査手順**
+
+1. **フロントエンド確認**
+   - ユーザー設定で「インライン再生」が有効か？
+     - 無効な場合: 埋め込みは試行されないので正常。`reveal_open_external` 率が高いのは問題なし。
+     - 有効な場合: 次へ進む。
+
+2. **URL 形式確認**
+   - [meta.ts](../../web/mocks/fixtures/rounds/meta.ts) の links 配列内の YouTube URL が正規形か確認
+   - 正規形（youtube.com/watch?v=ID または youtu.be/ID）以外の場合、修正が必要
+   ```javascript
+   // ✅ 正規形
+   { provider: 'youtube', url: 'https://www.youtube.com/watch?v=<VIDEO_ID>' }
+   { provider: 'youtube', url: 'https://youtu.be/<VIDEO_ID>' }
+
+   // ❌ 非対応形式
+   { provider: 'youtube', url: 'https://youtube.com/embed/<VIDEO_ID>' }
+   { provider: 'youtube', url: 'https://youtube.com/v/<VIDEO_ID>' }
+   ```
+
+3. **コード確認**
+   - [web/src/components/RevealCard.tsx](../../web/src/components/RevealCard.tsx) の `toYouTubeEmbed()` 関数が URL を正しく処理しているか
+   - ローカルで MSW に `embed_fallback_to_link` イベントがログに出るか確認
+   ```bash
+   npm run dev
+   # ブラウザの DevTools → Network タブで /metrics リクエスト検査
+   ```
+
+**対応**
+- URL が不正な場合: workers/data/curated.json を修正し、Deploy
+- インライン再生が無効な場合: ユーザーへ有効化を推奨（設定画面で toggle 操作）
+
+---
+
+### シナリオ 2: embed_error が多発
+
+**症状**
+- ダッシュボードで `embed_error` の割合が 3% を超えている
+- YouTube 埋め込みフレームが読み込まれるが「動画が見つかりません」的なエラー
+
+**調査手順**
+
+1. **埋め込みの動作確認**
+   - 問題の questionId を特定
+   - [meta.ts](../../web/mocks/fixtures/rounds/meta.ts) でその questionId の YouTube URL を確認
+   - 実際にその URL をブラウザで開き、動画が再生可能か確認
+
+2. **動画が再生不可能な場合（削除/非公開など）**
+   - YouTube から削除・非公開に
+   - 年齢制限が有効
+   - 特定国での地域制限
+
+   **対応**:
+   - 別の YouTube リンク（同じ作品の他バージョン）があれば workers/data/curated.json の該当トラック行を修正
+   - なければ、links 配列から問題の YouTube URL を削除し、他のプロバイダ（Spotify など）に依存させる
+
+3. **埋め込みが成功すべきなのに iframe.onError が発火する場合**
+   - ローカル環境での再現確認
+   ```bash
+   npm run test:e2e -- --grep "embed"
+   ```
+   - MSW モック内で YouTube 埋め込みを強制失敗させ、エラーハンドラが動作するか確認
+   - 本番環境の場合: CORS/CSP ポリシーが iframe.src ブロックしていないか確認
+     - web/next.config.ts の Security Headers を確認
+     - iframe allow 属性が必要な権限を許可しているか確認（[RevealCard.tsx](../../web/src/components/RevealCard.tsx) 参照）
+
+**対応**
+- 削除/制限された動画: curated.json から URL 削除、別リンクに置き換え
+- CORS/CSP 問題: セキュリティヘッダ調整（本番デプロイ時に検証が必要）
+
+---
+
+### シナリオ 3: reveal_open_external 率が異常に高い
+
+**症状**
+- ダッシュボードで `reveal_open_external` が 80% を超えている
+- ほぼすべてのユーザーが外部リンククリック
+
+**調査手順**
+
+1. **インライン再生設定の確認**
+   - localStorage の `vgm2.settings.inlinePlayback` を確認（0 = 無効, 1 = 有効）
+   - ブラウザ設定画面で「インライン再生」が無効になっていないか確認
+
+2. **embed 関連イベントの数値確認**
+   - `embed_fallback_to_link` + `embed_error` の合計が高い → シナリオ 1 or 2 の対応
+   - 両者が低い → インライン再生が無効、または埋め込みが成功しているのに外部クリックが多い（UX 問題かもしれない）
+
+**対応**
+- インライン再生が無効な場合: ユーザー教育（設定画面で有効化方法を案内）
+- 埋め込みが成功しているのに外部クリックが多い場合: UI/UX リビュー（「開く」ボタンが目立ちすぎていないか、など）
+
+---
+
+## 復旧手順
+
+### パターン A: URL 修正（データ品質）
+
+1. **問題の URL を特定**
+   ```bash
+   cd workers
+   npm run validate:curated
+   ```
+
+2. **workers/data/curated.json を修正**
+   ```json
+   {
+     "title": "Battle Theme",
+     "links": {
+       "youtube": "https://www.youtube.com/watch?v=CORRECTED_VIDEO_ID"
+     }
+   }
+   ```
+
+3. **検証と deploy**
+   ```bash
+   cd workers
+   npm run validate:curated
+   npm run typecheck
+   npm run deploy:api
+   npm run deploy:pipeline
+   ```
+
+4. **フロントエンド MSW モック更新**
+   - [meta.ts](../../web/mocks/fixtures/rounds/meta.ts) も同期
+   ```bash
+   cd web
+   npm run build && npm run test:e2e
+   ```
+
+### パターン B: 削除/制限動画の置き換え
+
+1. **別のプロバイダリンクを探す**
+   - 同じ作品の Spotify/Apple Music リンク
+   - 別の YouTube ミラー（公式チャンネルなど）
+
+2. **curated.json を更新**
+   ```json
+   {
+     "title": "Battle Theme",
+     "links": {
+       "spotify": "https://open.spotify.com/track/...",
+       "appleMusic": "https://music.apple.com/..."
+     }
+   }
+   ```
+
+3. **確認と deploy**
+   - ローカル MSW で確認
+   - E2E テストで reveal フロー動作確認
+   - 本番 deploy
+
+---
+
+## メトリクス確認方法
+
+### ローカル開発環境
+
+1. **metrics クライアント動作確認**
+   ```bash
+   cd web
+   npm run dev
+   # ブラウザ DevTools → Application → Local Storage
+   # vgm2.metrics.queue に pending イベントが溜まっているか確認
+   ```
+
+2. **MSW ハンドラ確認**
+   ```bash
+   # web/mocks/handlers.ts で /v1/metrics のハンドラをチェック
+   grep -A 10 "POST.*metrics" web/mocks/handlers.ts
+   ```
+
+3. **イベント送信ログ**
+   ```bash
+   # ブラウザコンソールで
+   localStorage.getItem('vgm2.metrics.queue')
+   ```
+
+### 本番環境
+
+- Grafana Cloud Dashboard で以下を表示
+  - `embed_fallback_to_link` の 24h 集計（日時別・provider 別）
+  - `embed_error` の 24h 集計
+  - `reveal_open_external` の 24h 集計
+  - 日別トレンド（低下傾向なら改善、上昇なら悪化）
+
+---
+
+## エスカレーション
+
+| 条件 | 判断 | 対応 |
+|------|------|------|
+| embed 関連イベント合計が 1 日 100 件以上 | Critical | 緊急対応：データ修正 → 検証 → デプロイ |
+| embed 関連イベント割合が 5% 以上（毎日継続） | High | 翌営業日対応：原因調査 → 修正計画 |
+| embed 関連イベント割合が 2～5%（散発的） | Medium | 定期レビュー対象：月次まとめて修正 |
+| embed 関連イベント割合が 2% 未満 | Normal | 監視継続 |
+
+---
+
+## 関連ドキュメント・リソース
+
+- [RevealCard コンポーネント](../../web/src/components/RevealCard.tsx) - 埋め込み実装
+- [メトリクスクライアント](../../web/src/lib/metrics/metricsClient.ts) - イベント送信
+- [curated.json](../../workers/data/curated.json) - マスターデータ
+- [API 仕様 - /v1/metrics](../../api/api-spec.md) - メトリクス受け入れスキーマ
+- [Observability & Alerts](../observability.md) - ダッシュボード・アラート設定
+
+---
+
+## 変更履歴
+
+- **2025-11-16**: Phase 3C 初版作成（Issue #35）

--- a/docs/ops/runbooks/audio-playback.md
+++ b/docs/ops/runbooks/audio-playback.md
@@ -58,7 +58,7 @@ Reveal Card で以下のイベントを記録：
      - 有効な場合: 次へ進む。
 
 2. **URL 形式確認**
-   - [meta.ts](../../web/mocks/fixtures/rounds/meta.ts) の links 配列内の YouTube URL が正規形か確認
+- [meta.ts](../../../web/mocks/fixtures/rounds/meta.ts) の links 配列内の YouTube URL が正規形か確認
    - 正規形（youtube.com/watch?v=ID または youtu.be/ID）以外の場合、修正が必要
    ```javascript
    // ✅ 正規形
@@ -71,7 +71,7 @@ Reveal Card で以下のイベントを記録：
    ```
 
 3. **コード確認**
-   - [web/src/components/RevealCard.tsx](../../web/src/components/RevealCard.tsx) の `toYouTubeEmbed()` 関数が URL を正しく処理しているか
+- [web/src/components/RevealCard.tsx](../../../web/src/components/RevealCard.tsx) の `toYouTubeEmbed()` 関数が URL を正しく処理しているか
    - ローカルで MSW に `embed_fallback_to_link` イベントがログに出るか確認
    ```bash
    npm run dev
@@ -94,7 +94,7 @@ Reveal Card で以下のイベントを記録：
 
 1. **埋め込みの動作確認**
    - 問題の questionId を特定
-   - [meta.ts](../../web/mocks/fixtures/rounds/meta.ts) でその questionId の YouTube URL を確認
+- [meta.ts](../../../web/mocks/fixtures/rounds/meta.ts) でその questionId の YouTube URL を確認
    - 実際にその URL をブラウザで開き、動画が再生可能か確認
 
 2. **動画が再生不可能な場合（削除/非公開など）**
@@ -254,7 +254,7 @@ Reveal Card で以下のイベントを記録：
 - [RevealCard コンポーネント](../../web/src/components/RevealCard.tsx) - 埋め込み実装
 - [メトリクスクライアント](../../web/src/lib/metrics/metricsClient.ts) - イベント送信
 - [curated.json](../../workers/data/curated.json) - マスターデータ
-- [API 仕様 - /v1/metrics](../../api/api-spec.md) - メトリクス受け入れスキーマ
+- [API 仕様 - /v1/metrics](../../../api/api-spec.md) - メトリクス受け入れスキーマ
 - [Observability & Alerts](../observability.md) - ダッシュボード・アラート設定
 
 ---

--- a/docs/ops/runbooks/audio-playback.md
+++ b/docs/ops/runbooks/audio-playback.md
@@ -114,7 +114,7 @@ Reveal Card で以下のイベントを記録：
    - MSW モック内で YouTube 埋め込みを強制失敗させ、エラーハンドラが動作するか確認
    - 本番環境の場合: CORS/CSP ポリシーが iframe.src ブロックしていないか確認
      - web/next.config.ts の Security Headers を確認
-     - iframe allow 属性が必要な権限を許可しているか確認（[RevealCard.tsx](../../web/src/components/RevealCard.tsx) 参照）
+     - iframe allow 属性が必要な権限を許可しているか確認（[RevealCard.tsx](../../../web/src/components/RevealCard.tsx) 参照）
 
 **対応**
 - 削除/制限された動画: curated.json から URL 削除、別リンクに置き換え
@@ -174,7 +174,7 @@ Reveal Card で以下のイベントを記録：
    ```
 
 4. **フロントエンド MSW モック更新**
-   - [meta.ts](../../web/mocks/fixtures/rounds/meta.ts) も同期
+   - [meta.ts](../../../web/mocks/fixtures/rounds/meta.ts) も同期
    ```bash
    cd web
    npm run build && npm run test:e2e
@@ -251,9 +251,9 @@ Reveal Card で以下のイベントを記録：
 
 ## 関連ドキュメント・リソース
 
-- [RevealCard コンポーネント](../../web/src/components/RevealCard.tsx) - 埋め込み実装
-- [メトリクスクライアント](../../web/src/lib/metrics/metricsClient.ts) - イベント送信
-- [curated.json](../../workers/data/curated.json) - マスターデータ
+- [RevealCard コンポーネント](../../../web/src/components/RevealCard.tsx) - 埋め込み実装
+- [メトリクスクライアント](../../../web/src/lib/metrics/metricsClient.ts) - イベント送信
+- [curated.json](../../../workers/data/curated.json) - マスターデータ
 - [API 仕様 - /v1/metrics](../../../api/api-spec.md) - メトリクス受け入れスキーマ
 - [Observability & Alerts](../observability.md) - ダッシュボード・アラート設定
 

--- a/docs/ops/runbooks/audio-playback.md
+++ b/docs/ops/runbooks/audio-playback.md
@@ -26,19 +26,21 @@ Reveal Card で以下のイベントを記録：
 
 ### ダッシュボード・アラートの設定例
 
-1. **Embed Fallback Rate** (`embed_fallback_to_link` / `reveal_view`)
+1. **Embed Fallback Rate** (`embed_fallback_to_link` / `answer_result (inlineEnabled=1)`)
    - 目標: < 5% per day
    - しきい値: 5% 以上で Slack #vgm-ops に注意通知
    - アクション: データ品質チェック（URL 修正が必要か確認）
 
-2. **Embed Load Error Rate** (`embed_error` / `embed_attempt`)
+2. **Embed Load Error Rate** (`embed_error` / `embed_attempt` = `inlineEnabled answer_result` − `embed_fallback_to_link`)
    - 目標: < 2% per day
    - しきい値: 3% 以上で Slack #vgm-ops に警告通知
    - アクション: YouTube 動画の可用性確認（削除/制限）
 
-3. **External Open Rate** (`reveal_open_external` / `reveal_view`)
+3. **External Open Rate** (`reveal_open_external` / `answer_result`)
    - 参考指標（必ずしも問題ではない）
    - > 80% が外部へ遷移している場合: インライン再生設定の確認
+
+> `answer_result` では `attrs.inlineEnabled` を送信しており、インライン再生が ON の設問だけを分母に含められる。メトリクス設計の詳細は `docs/quality/measurement-plan.md` を参照。
 
 ---
 

--- a/docs/quality/measurement-plan.md
+++ b/docs/quality/measurement-plan.md
@@ -1,0 +1,498 @@
+# 計測設計・イベント→指標マッピング (Phase 3C)
+
+**ステータス**: Phase 3C 初版
+**対象バージョン**: Phase 2B 以降
+**最終更新**: 2025-11-16
+
+---
+
+## 目的
+
+「どこでどのイベントを送るか」「どのイベントがどの指標に使われるか」を図解し、**計測漏れ防止**と**集計 SQL の仕様書**として機能させる。
+
+---
+
+## イベント一覧と送信ポイント
+
+| イベント | 送信元コンポーネント | 発火条件 | 属性 | 指標への使用 |
+|---------|------------------|--------|------|-----------|
+| `quiz_complete` | [useAnswerProcessor.ts](../../web/src/features/quiz/useAnswerProcessor.ts) | 最後の問題に回答した時点 | roundId, attrs{total, points, correct, wrong, timeout, skip, durationMs} | Completion Rate 分子 |
+| `reveal_open_external` | [RevealCard.tsx](../../web/src/components/RevealCard.tsx) | ユーザーが「Open in X」をクリック | roundId, questionIdx, attrs{questionId, provider} | Outbound Rate 分子 |
+| `embed_fallback_to_link` | [RevealCard.tsx](../../web/src/components/RevealCard.tsx) | インライン再生有効 + URL 変換失敗 | roundId, questionIdx, attrs{questionId, provider, reason: 'no_embed_available'} | Embed Fallback Rate 分子 |
+| `embed_error` | [RevealCard.tsx](../../web/src/components/RevealCard.tsx) | iframe.onError 発火 | roundId, questionIdx, attrs{questionId, provider, reason: 'load_error'} | Embed Load Error Rate 分子 |
+
+---
+
+## 計測フロー図
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   User Quiz Session                         │
+│                    roundId = UUID                           │
+└─────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  POST /v1/rounds/start              │
+        │  ├─ filters: {difficulty?, era?}    │
+        │  ├─ total: 10                       │
+        │  └─ Response: {round.token, q1}     │
+        └─────────────────────────────────────┘
+         ★ Completion Rate 分母カウント ★
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  [1] Question Presented             │
+        │  └─ display_time: 15秒 (固定)      │
+        └─────────────────────────────────────┘
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  [2] User Select Choice             │
+        │  └─ trigger: answer_select event    │
+        └─────────────────────────────────────┘
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  [3] Submit Answer or Timeout       │
+        │  └─ POST /v1/rounds/next {token}    │
+        │     ├─ Response: {reveal, next?}    │
+        │     └─ Sent: answer_result event    │
+        └─────────────────────────────────────┘
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  [4] Reveal Display (RevealCard)    │
+        │  ├─ show meta (composer, game)      │
+        │  ├─ try embed (YouTube)             │
+        │  └─ show external link              │
+        └─────────────────────────────────────┘
+                    ↙         ↓         ↖
+         embed     fallback  success   error
+         不可能      不可      再生     失敗
+            │          │        │       │
+            ▼          ▼        ▼       ▼
+        [EVENT]   [EVENT]   [UI]    [EVENT]
+        fallback   fallback  only    error
+        to_link    to_link   link   on iframe
+            │          │        │       │
+            └─ fallback ────────┘       │
+                  │                     │
+                  └──── or click ◄──────┘
+                         external
+                         link
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  [FALLBACK] reveal_open_external    │
+        │  └─ attrs: {provider: 'youtube'}    │
+        └─────────────────────────────────────┘
+                          │
+                  ┌───────┴───────┐
+                  ▼               ▼
+            (外部サイト)    (ユーザー戻る)
+                          │
+                          ▼
+        ┌─────────────────────────────────────┐
+        │  [5] Next or Finish                 │
+        │  ├─ if finished:                    │
+        │  │   └─ quiz_complete ★             │
+        │  └─ if next:                        │
+        │      └─ → back to [1]              │
+        └─────────────────────────────────────┘
+```
+
+---
+
+## イベント詳細仕様と計測ロジック
+
+### 1. quiz_complete イベント
+
+**発火ポイント**: `useAnswerProcessor.ts` の `handleFinish()` →フロントエンド最終状態
+
+```typescript
+// 送信タイミング
+if (res.finished === true) {
+  recordMetricsEvent('quiz_complete', {
+    roundId: continuationToken,
+    attrs: {
+      total: totalQuestions,
+      points: updatedTally.points,
+      correct: updatedTally.correct,
+      wrong: updatedTally.wrong,
+      timeout: updatedTally.timeout,
+      skip: updatedTally.skip,
+      durationMs,
+    },
+  })
+}
+```
+
+**属性定義**
+
+| 属性 | 型 | 例 | 用途 |
+|------|-----|-----|------|
+| roundId | string | "550e8400-e29b-41d4-a716-446655440000" | セッション特定 |
+| attrs.total | number | 10 | 総問題数 |
+| attrs.points | number | 850 | 合計スコア |
+| attrs.correct | number | 7 | 正解数 |
+| attrs.wrong | number | 2 | 不正解数 |
+| attrs.skip | number | 1 | スキップ数 |
+| attrs.timeout | number | 0 | タイムアウト数 |
+| attrs.durationMs | number | 142000 | セッション総所要時間（ミリ秒） |
+
+**集計ロジック（SQL 例）**
+
+```sql
+-- Completion Rate = Complete / Started × 100% (D1/SQLite)
+SELECT
+  DATE(ts) as date,
+  COUNT(DISTINCT CASE WHEN event_name = 'quiz_complete' THEN round_id END) as completed,
+  COUNT(DISTINCT round_id) as started,
+  ROUND(
+    COUNT(DISTINCT CASE WHEN event_name = 'quiz_complete' THEN round_id END)
+    * 100.0 / COUNT(DISTINCT round_id),
+    2
+  ) as completion_rate_pct
+FROM metrics_events
+WHERE event_name IN ('quiz_complete', 'answer_result')
+GROUP BY DATE(ts)
+ORDER BY date DESC;
+```
+
+**再送条件**
+- 送信失敗時: localStorage キューに格納、指数バックオフで最大 5 回まで再試行
+  - BASE_RETRY_MS=2000ms、RETRY_JITTER_RATIO=0.25
+  - 再試行間隔: 2s, 4s, 8s, 16s, 32s (jitter ±25%)
+- 重複防止: `roundId` で冪等性確保（questionIdx は quiz_complete には含まれないため）
+
+---
+
+### 2. reveal_open_external イベント
+
+**発火ポイント**: `RevealCard.tsx` の `handleExternalClick()` → ユーザーアクション
+
+```typescript
+// 送信タイミング
+const handleExternalClick = useCallback(() => {
+  if (!primary) return;
+  recordMetricsEvent('reveal_open_external', {
+    roundId: telemetry?.roundId,
+    questionIdx: telemetry?.questionIdx,
+    attrs: {
+      questionId: telemetry?.questionId,
+      provider: primary.provider,
+    },
+  });
+}, [primary, telemetry?.roundId, telemetry?.questionIdx, telemetry?.questionId]);
+```
+
+**属性定義**
+
+| 属性 | 型 | 例 | 用途 |
+|------|-----|-----|------|
+| roundId | string | "550e8400-..." | セッション特定 |
+| questionIdx | number | 3 | 問題位置 |
+| attrs.questionId | string | "q-001" | トラック特定 |
+| attrs.provider | string | "youtube" | プロバイダ別集計 |
+
+**集計ロジック（SQL 例）**
+
+```sql
+-- Outbound Rate = External Clicks / Total Reveals × 100% (D1/SQLite)
+-- Reveal = quiz_complete + embed_error + embed_fallback_to_link (重複排除)
+-- 注: reveal_view は実イベントではなく代理イベント（合成）
+WITH reveals AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(DISTINCT round_id || ':' || COALESCE(question_idx, '')) as total_reveals
+  FROM metrics_events
+  WHERE event_name IN (
+    'quiz_complete', 'embed_error', 'embed_fallback_to_link'
+  )
+  GROUP BY DATE(ts)
+),
+outbound AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(*) as external_clicks
+  FROM metrics_events
+  WHERE event_name = 'reveal_open_external'
+  GROUP BY DATE(ts)
+)
+SELECT
+  r.date,
+  r.total_reveals,
+  COALESCE(o.external_clicks, 0) as external_clicks,
+  ROUND(
+    COALESCE(o.external_clicks, 0) * 100.0 / r.total_reveals,
+    2
+  ) as outbound_rate_pct
+FROM reveals r
+LEFT JOIN outbound o ON r.date = o.date
+ORDER BY r.date DESC;
+```
+
+**再送条件**
+- 送信失敗時: localStorage キューに格納、指数バックオフで最大 5 回まで再試行
+- 欠損時の扱い: クリック回数ゼロは「ユーザーが外部リンク未利用」で正常
+
+---
+
+### 3. embed_fallback_to_link イベント
+
+**発火ポイント**: `RevealCard.tsx` の useEffect → コンポーネント初期化時
+
+```typescript
+// 送信タイミング
+React.useEffect(() => {
+  if (!inline) return; // インライン再生無効なら送信しない
+  if (!primary) return;
+  if (embedUrl) return; // 埋め込み可能なら送信しない
+  if (fallbackLogged) return; // 重複送信防止
+
+  recordMetricsEvent('embed_fallback_to_link', {
+    roundId: telemetry?.roundId,
+    questionIdx: telemetry?.questionIdx,
+    attrs: {
+      questionId: telemetry?.questionId,
+      provider: primary.provider,
+      reason: 'no_embed_available',
+    },
+  });
+  setFallbackLogged(true);
+}, [inline, primary, embedUrl, fallbackLogged, ...deps]);
+```
+
+**属性定義**
+
+| 属性 | 型 | 値 | 用途 |
+|------|-----|-----|------|
+| roundId | string | "550e8400-..." | セッション特定 |
+| questionIdx | number | 5 | 問題位置 |
+| attrs.questionId | string | "q-025" | トラック特定 |
+| attrs.provider | string | "youtube" | プロバイダ |
+| attrs.reason | string | "no_embed_available" | 原因分類（定数） |
+
+**送信条件の詳細**
+- インライン再生が有効（localStorage `vgm2.settings.inlinePlayback = 1`）
+- URL が `toYouTubeEmbed()` で埋め込み URL に変換できない
+- 同じ question に対して 1 回のみ送信（`fallbackLogged` フラグで制御）
+
+**集計ロジック（SQL 例）**
+
+```sql
+-- Embed Fallback Rate = Fallback Events / Total Reveals × 100% (D1/SQLite)
+WITH reveals AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(DISTINCT round_id || ':' || COALESCE(question_idx, '')) as total_reveals
+  FROM metrics_events
+  WHERE event_name IN (
+    'quiz_complete', 'embed_error', 'embed_fallback_to_link'
+  )
+  GROUP BY DATE(ts)
+),
+fallback AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(*) as fallback_events
+  FROM metrics_events
+  WHERE event_name = 'embed_fallback_to_link'
+    AND json_extract(attrs, '$.reason') = 'no_embed_available'
+  GROUP BY DATE(ts)
+)
+SELECT
+  r.date,
+  r.total_reveals,
+  COALESCE(f.fallback_events, 0) as fallback_events,
+  ROUND(
+    COALESCE(f.fallback_events, 0) * 100.0 / r.total_reveals,
+    2
+  ) as fallback_rate_pct
+FROM reveals r
+LEFT JOIN fallback f ON r.date = f.date
+ORDER BY r.date DESC;
+```
+
+**再送条件**
+- 送信失敗時: localStorage キューに格納、指数バックオフで最大 5 回まで再試行
+- 計測漏れ時: 「この reveal に対して fallback イベントなし」 = 埋め込み成功と推定
+
+---
+
+### 4. embed_error イベント
+
+**発火ポイント**: `RevealCard.tsx` の `handleEmbedError()` → iframe.onError コールバック
+
+```typescript
+// 送信タイミング
+const handleEmbedError = useCallback(() => {
+  if (errorLogged || !primary) return;
+  setErrorLogged(true);
+
+  recordMetricsEvent('embed_error', {
+    roundId: telemetry?.roundId,
+    questionIdx: telemetry?.questionIdx,
+    attrs: {
+      questionId: telemetry?.questionId,
+      provider: primary.provider,
+      reason: 'load_error',
+    },
+  });
+}, [errorLogged, primary, telemetry?.roundId, telemetry?.questionIdx, telemetry?.questionId]);
+```
+
+**属性定義**
+
+| 属性 | 型 | 値 | 用途 |
+|------|-----|-----|------|
+| roundId | string | "550e8400-..." | セッション特定 |
+| questionIdx | number | 7 | 問題位置 |
+| attrs.questionId | string | "q-042" | トラック特定 |
+| attrs.provider | string | "youtube" | プロバイダ |
+| attrs.reason | string | "load_error" | エラー原因（定数） |
+
+**発火条件の詳細**
+- 埋め込み URL は有効（`toYouTubeEmbed()` 成功）
+- iframe が作成され、src が設定された
+- iframe.onError がブラウザで発火（動画削除、年齢制限、地域制限、network エラーなど）
+- 同じ question に対して 1 回のみ送信（`errorLogged` フラグで制御）
+
+**集計ロジック（SQL 例）**
+
+```sql
+-- Embed Load Error Rate = Error Events / Embed Attempts × 100% (D1/SQLite)
+-- Embed Attempts = Total Reveals - Fallback Events
+WITH reveals AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(DISTINCT round_id || ':' || COALESCE(question_idx, '')) as total_reveals
+  FROM metrics_events
+  WHERE event_name IN (
+    'quiz_complete', 'embed_error', 'embed_fallback_to_link'
+  )
+  GROUP BY DATE(ts)
+),
+fallback AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(*) as fallback_count
+  FROM metrics_events
+  WHERE event_name = 'embed_fallback_to_link'
+  GROUP BY DATE(ts)
+),
+errors AS (
+  SELECT
+    DATE(ts) as date,
+    COUNT(*) as error_count
+  FROM metrics_events
+  WHERE event_name = 'embed_error'
+    AND json_extract(attrs, '$.reason') = 'load_error'
+  GROUP BY DATE(ts)
+)
+SELECT
+  r.date,
+  (r.total_reveals - COALESCE(f.fallback_count, 0)) as embed_attempts,
+  COALESCE(e.error_count, 0) as error_events,
+  ROUND(
+    COALESCE(e.error_count, 0) * 100.0
+    / NULLIF(r.total_reveals - COALESCE(f.fallback_count, 0), 0),
+    2
+  ) as error_rate_pct
+FROM reveals r
+LEFT JOIN fallback f ON r.date = f.date
+LEFT JOIN errors e ON r.date = e.date
+ORDER BY r.date DESC;
+```
+
+**再送条件**
+- 送信失敗時: localStorage キューに格納、指数バックオフで最大 5 回まで再試行
+- ネットワーク遅延時: iframe.onError は即座に発火するため、タイムアウト問題は通常なし
+
+---
+
+## 計測チェックリスト（実装時）
+
+### フロントエンド
+
+- [ ] `quiz_complete` イベント実装
+  - [ ] roundId 取得可能か確認
+  - [ ] total, points, correct, wrong, skip, timeout, durationMs 計算正確か
+  - [ ] 最後の問題のみ送信されるか確認
+  - [ ] questionIdx は含まれないことを確認（セッション全体の集計のため）
+
+- [ ] `reveal_open_external` イベント実装
+  - [ ] ユーザーリンククリック時のみ送信
+  - [ ] questionId, provider 属性が正確か
+
+- [ ] `embed_fallback_to_link` イベント実装
+  - [ ] インライン再生有効時のみ送信
+  - [ ] URL 変換失敗時のみ送信
+  - [ ] 同じ question への重複送信なし（fallbackLogged フラグ）
+
+- [ ] `embed_error` イベント実装
+  - [ ] iframe.onError 時のみ送信
+  - [ ] 同じ question への重複送信なし（errorLogged フラグ）
+
+### バックエンド
+
+- [ ] `/v1/metrics` エンドポイント動作確認
+  - [ ] 全 4 イベント名がホワイトリストに登録
+  - [ ] 属性検証ロジック完全か
+  - [ ] D1 永続化成功か
+
+- [ ] イベント重複排除
+  - [ ] idempotencyKey による冪等性確保
+  - [ ] 同一イベント 2 回受信時の挙動
+
+### 計測・集計
+
+- [ ] Grafana / Loki ダッシュボード実装
+  - [ ] 上記 SQL クエリをプリセットに登録
+  - [ ] 日別グラフが 7 日分表示
+  - [ ] フィルタ別内訳（difficulty/era/provider）も表示可能か
+
+---
+
+## イベント欠損時の扱い
+
+| シナリオ | イベント | 推定方法 | 正確性 |
+|--------|---------|--------|------|
+| `quiz_complete` なし | ユーザーが途中離脱 | `/v1/rounds/start` - `quiz_complete` = 未完走 | 高 |
+| `reveal_open_external` なし | ユーザーが外部クリックしない | 0 イベント = 埋め込みのみ利用 | 高 |
+| `embed_fallback_to_link` なし + embed_error なし | 埋め込み成功 | Reveal view - fallback - error = 成功 | 中 |
+| `embed_error` なし | iframe は read only | Unknown - ブラウザが onError を発火しないケースもあり | 低 |
+
+**影響**: Embed Load Error Rate 計算時、分母の iframe.onError カウント が低めに出る可能性あり。定期的に manual spot check で検証。
+
+---
+
+## 環境別の注意
+
+### ローカル開発（MSW モック）
+
+- MSW ハンドラが `/v1/metrics` リクエストを受け取り、localStorage に蓄積
+- ダッシュボード不可（本番環境で初めて動作）
+- イベント列をコンソール / DevTools で目視確認
+
+### ステージング / 本番
+
+- リアルな `/v1/metrics` エンドポイントへ送信
+- Grafana Cloud Loki に 24h ロールアップ
+- アラート自動トリガー設定
+
+---
+
+## 関連ドキュメント
+
+- [quality/metrics.md](metrics.md) - KPI 指標定義
+- [api/api-spec.md#post-v1metrics](../api/api-spec.md#post-v1metrics) - /v1/metrics エンドポイント仕様
+- [ops/runbooks/audio-playback.md](../ops/runbooks/audio-playback.md) - Embed 失敗時の初動対応
+- [frontend/metrics-client.md](../frontend/metrics-client.md) - メトリクスクライアント実装
+
+---
+
+## 変更履歴
+
+- **2025-11-16**: Phase 3C 初版作成（Issue #33）

--- a/docs/quality/measurement-plan.md
+++ b/docs/quality/measurement-plan.md
@@ -379,12 +379,12 @@ fallback AS (
 ),
 errors AS (
   SELECT
-    DATE(ts) as date,
+    DATE(event_ts) as date,
     COUNT(*) as error_count
   FROM metrics_events
   WHERE event_name = 'embed_error'
     AND json_extract(attrs, '$.reason') = 'load_error'
-  GROUP BY DATE(ts)
+  GROUP BY DATE(event_ts)
 )
 SELECT
   a.date,

--- a/docs/quality/metrics.md
+++ b/docs/quality/metrics.md
@@ -138,7 +138,7 @@ Embed Fallback Rate = embed_fallback_to_link イベント数 / answer_result イ
 | 項目 | 値 |
 |------|-----|
 | 分子 | `embed_fallback_to_link` イベント数（reason = 'no_embed_available'） |
-| 分母 | Reveal 表示回数の代理: `answer_result` イベント数（設問ごとに必ず 1 回送信） |
+| 分母 | インライン再生が有効だった Reveal 回数: `answer_result` (attrs.inlineEnabled = true) |
 | 集計粒度 | 日次、提供元別（provider: youtube/spotify/appleMusic） |
 | 計測期間 | 7 日（週次レビュー） |
 
@@ -149,7 +149,8 @@ Embed Fallback Rate = embed_fallback_to_link イベント数 / answer_result イ
 - 原因: URL が youtube.com/watch?v=<ID> または youtu.be/<ID> 形式でない、または URL パース失敗
 
 **分母の定義**
-- イベント: `answer_result`（各設問で必ず送信され、直後に Reveal が表示される）
+- イベント: `answer_result`
+- フィルタ: `attrs.inlineEnabled = true`（インライン再生 ON の設問のみ）
 - 集計: `COUNT(DISTINCT round_id || ':' || question_idx)`
 
 **目標値と閾値**
@@ -187,7 +188,7 @@ Embed Load Error Rate = embed_error イベント数 / (embed_attempt 数) × 100
 | 項目 | 値 |
 |------|-----|
 | 分子 | `embed_error` イベント数（reason = 'load_error'） |
-| 分母 | 埋め込み試行数（= reveal 表示数 - fallback 数）|
+| 分母 | インライン再生 ON の埋め込み試行数（= inlineEnabled `answer_result` 数 - fallback 数）|
 | 集計粒度 | 日次、ジャンル別・難易度別（メタデータ join） |
 | 計測期間 | 7 日（週次レビュー） |
 
@@ -198,8 +199,8 @@ Embed Load Error Rate = embed_error イベント数 / (embed_attempt 数) × 100
 - 原因: 動画削除、非公開化、年齢制限、地域制限、ネットワークエラーなど
 
 **分母の定義**
-- **Embed Attempt**: 各設問の reveal で「埋め込みを試行した回数」の代理
-  - proxy: `answer_result` の設問数 − `embed_fallback_to_link`（URL 変換できず試行しなかった分を除外）
+- **Embed Attempt**: `answer_result` (attrs.inlineEnabled = true) から `embed_fallback_to_link` を差し引いた値
+  - フィルタ: `attrs.inlineEnabled = true`
   - 集計: `COUNT(DISTINCT round_id || ':' || question_idx)` をベースに計算
 
 **目標値と閾値**

--- a/docs/quality/metrics.md
+++ b/docs/quality/metrics.md
@@ -1,0 +1,288 @@
+# KPI 指標定義 (Phase 3C)
+
+**ステータス**: Phase 3C 初版
+**対象バージョン**: Phase 2B 以降
+**最終更新**: 2025-11-16
+
+---
+
+## 目的
+
+週間 KPI の定義を文書化し、ビジネス・技術チーム全体で同じ指標言語を共有する。各 KPI は「何を測るか」「なぜ測るか」「いつ正常か」を明示し、ダッシュボード実装とアラート閾値設定の基盤となる。
+
+---
+
+## KPI 一覧
+
+| 指標 | カテゴリ | 対象 | 目標 | 計測対象イベント |
+|------|---------|------|------|-----------------|
+| [Completion Rate](#completion-rate--完走率) | Core Engagement | Quiz Session | > 80% | `quiz_complete` |
+| [Outbound Rate](#outbound-rate--外部遷移率) | User Behavior | Reveal View | 参考指標 | `reveal_open_external` |
+| [Embed Fallback Rate](#embed-fallback-rate--埋め込み失敗率) | Playback Quality | Reveal View | < 5% | `embed_fallback_to_link` |
+| [Embed Load Error Rate](#embed-load-error-rate--読み込みエラー率) | Playback Quality | Embed Attempt | < 2% | `embed_error` |
+
+---
+
+## Core Engagement Metrics
+
+### Completion Rate — 完走率
+
+**定義**: ユーザーがクイズを開始してから、最後の問題に回答するまで完走した割合。
+
+**ビジネス目的**
+- アプリの粘着性を測る（ユーザーが途中で離脱していないか）
+- UI 改善による離脱削減の効果測定
+
+**計算式**
+```
+Completion Rate = quiz_complete イベント数 / (round/start API コール数 - エラー) × 100%
+```
+
+**詳細**
+
+| 項目 | 値 |
+|------|-----|
+| 分子 | `quiz_complete` イベント数 |
+| 分母 | `/v1/rounds/start` レスポンス成功件数 |
+| 集計粒度 | 日次、フィルタ別（difficulty/era/series）|
+| 計測期間 | 7 日（週次レビュー） |
+
+**分子の定義**
+- イベント: `quiz_complete`
+- 発火タイミング: `/v1/rounds/next` で最後の問題に対する回答が返された時点
+- 属性: `roundId`, `attrs.total`, `attrs.points`, `attrs.correct`, `attrs.wrong`, `attrs.skip`, `attrs.timeout`, `attrs.durationMs`
+- ユーザーセッション追跡: `roundId` + `clientId` で join
+
+**分母の定義**
+- API: `POST /v1/rounds/start` の成功レスポンス（HTTP 200）
+- フィルタ別計測: リクエスト body の `filters` パラメータで groupby
+
+**目標値と閾値**
+
+| 基準 | 値 | 対応 |
+|-----|-----|------|
+| 目標 | > 80% | ユーザー粘着性が十分 |
+| 警告 | 70～80% | 離脱が増加：UI/UX 確認 |
+| アラート | < 70% | 緊急：エラーログ確認、即座に対応 |
+
+**ダッシュボード表示**
+- 日別折線グラフ（7 日間）
+- フィルタ別の内訳（積み上げ棒グラフ）
+- 前週比 % 表示
+
+---
+
+## User Behavior Metrics
+
+### Outbound Rate — 外部遷移率
+
+**定義**: Reveal 画面でユーザーが「YouTube/Spotify で開く」ボタンをクリックした割合。
+
+**ビジネス目的**
+- ユーザーが埋め込みプレイヤーを経由してではなく、外部サービスで曲を聴いている行動を捕捉
+- インライン再生設定やプロバイダ別の人気度を測る
+
+**計算式**
+```
+Outbound Rate = reveal_open_external イベント数 / reveal_view イベント数 × 100%
+```
+
+**詳細**
+
+| 項目 | 値 |
+|------|-----|
+| 分子 | `reveal_open_external` イベント数 |
+| 分母 | Reveal Card が表示された回数（代理: `quiz_complete` + `embed_error` + `embed_fallback_to_link`） |
+| 集計粒度 | 日次、プロバイダ別（youtube/spotify/appleMusic/other） |
+| 計測期間 | 7 日（週次レビュー） |
+
+**分子の定義**
+- イベント: `reveal_open_external`
+- 発火タイミング: ユーザーが「Open in X」リンクをクリック
+- 属性: `roundId`, `questionIdx`, `attrs.provider`
+
+**分母の定義**
+- **Reveal View 代理イベント**:
+  - `quiz_complete`: ユーザーが最後の問題に回答した → reveal が表示されたと推定
+  - `embed_error`: iframe エラー → リンク fallback で reveal が強制表示
+  - `embed_fallback_to_link`: 埋め込み不可 → リンク表示
+  - 式: `quiz_complete + embed_error + embed_fallback_to_link` (重複排除は `questionId` + `roundId` で)
+
+**参考指標の意味**
+- > 80%: ユーザーの大多数が外部サービスを活用（正常な利用パターン）
+- 50～80%: 埋め込みと外部リンクが混在（インライン再生が有効/無効が混在）
+- < 50%: インライン再生が活発で埋め込み成功率が高い（プレイヤー品質が良好）
+
+**ダッシュボード表示**
+- プロバイダ別積み上げ棒グラフ
+- 日別トレンド（参考値）
+- 注釈: 「参考指標のため、単独では問題判定しない」
+
+---
+
+## Playback Quality Metrics
+
+### Embed Fallback Rate — 埋め込み失敗率（URL 変換失敗）
+
+**定義**: YouTube 埋め込みが試行されたが、URL が埋め込み可能形式に変換できず、ユーザーに リンク fallback が強制された割合。
+
+**ビジネス目的**
+- ソースデータ品質（curated.json の URL 正確性）を測る
+- 修正優先度の判定（数値が高い = 多くのトラックが不正な URL を持つ）
+
+**計算式**
+```
+Embed Fallback Rate = embed_fallback_to_link イベント数 / (reveal_view 数) × 100%
+```
+
+**詳細**
+
+| 項目 | 値 |
+|------|-----|
+| 分子 | `embed_fallback_to_link` イベント数（reason = 'no_embed_available'） |
+| 分母 | Reveal View 推定数（`quiz_complete` + `embed_error` + `embed_fallback_to_link`） |
+| 集計粒度 | 日次、提供元別（provider: youtube/spotify/appleMusic） |
+| 計測期間 | 7 日（週次レビュー） |
+
+**分子の定義**
+- イベント: `embed_fallback_to_link`
+- 発火条件: インライン再生有効 + URL を `toYouTubeEmbed()` で変換できない
+- 属性: `roundId`, `questionIdx`, `attrs.questionId`, `attrs.provider`, `attrs.reason: 'no_embed_available'`
+- 原因: URL が youtube.com/watch?v=<ID> または youtu.be/<ID> 形式でない、または URL パース失敗
+
+**分母の定義**
+- **Reveal View**: [Outbound Rate](#outbound-rate--外部遷移率) と同じ代理イベント
+
+**目標値と閾値**
+
+| 基準 | 値 | 対応 |
+|-----|-----|------|
+| 目標 | < 5% | ソースデータ品質が十分 |
+| 警告 | 5～10% | データ修正案件あり：curated.json URL 再検証 |
+| アラート | > 10% | 深刻な品質問題：緊急データ修正、検証テスト追加 |
+
+**ダッシュボード表示**
+- 日別折線グラフ（7 日間）
+- 問題のある questionId トップ 10（再発防止）
+- 修正予定日との連携（JIRA チケット）
+
+---
+
+### Embed Load Error Rate — 読み込みエラー率
+
+**定義**: 埋め込みプレイヤーフレーム（iframe）が設定されたが、読み込み時に onError イベントが発火した割合。
+
+**現在の実装**: YouTube プロバイダのみ対応。他プロバイダ（Spotify、Apple Music など）が埋め込み対応される場合、attrs.provider ごとに分析。
+
+**ビジネス目的**
+- コンテンツ提供プラットフォーム（YouTube など）の可用性（削除/非公開/年齢制限など）を測る
+- 定期的な外部リンク監視の優先順位を決める
+
+**計算式**
+```
+Embed Load Error Rate = embed_error イベント数 / (embed_attempt 数) × 100%
+```
+
+**詳細**
+
+| 項目 | 値 |
+|------|-----|
+| 分子 | `embed_error` イベント数（reason = 'load_error'） |
+| 分母 | 埋め込み試行数（= reveal 表示数 - fallback 数）|
+| 集計粒度 | 日次、ジャンル別・難易度別（メタデータ join） |
+| 計測期間 | 7 日（週次レビュー） |
+
+**分子の定義**
+- イベント: `embed_error`
+- 発火条件: iframe.onError が発火
+- 属性: `roundId`, `questionIdx`, `attrs.questionId`, `attrs.provider: 'youtube'`, `attrs.reason: 'load_error'`
+- 原因: 動画削除、非公開化、年齢制限、地域制限、ネットワークエラーなど
+
+**分母の定義**
+- **Embed Attempt**: 埋め込み可能な URL が設定された reveal 数
+  - = 全 reveal - `embed_fallback_to_link`
+  - = `quiz_complete` + `embed_error`（重複排除）
+
+**目標値と閾値**
+
+| 基準 | 値 | 対応 |
+|-----|-----|------|
+| 目標 | < 2% | YouTube 動画の可用性が十分 |
+| 警告 | 2～3% | 月次で監視対象リスト作成 |
+| アラート | > 3% | 緊急：YouTube リンク大量削除/制限の可能性、即座に影響トラック確認 |
+
+**ダッシュボード表示**
+- 日別折線グラフ（7 日間）
+- エラーが発生した questionId リスト（削除候補）
+- 修正完了までのカウントダウン（SLA）
+
+---
+
+## メトリクス間の関係図
+
+```
+Reveal View (分母)
+  ├─ embed_fallback_to_link (埋め込み失敗)
+  │   └─ → ユーザーにリンク fallback が表示
+  ├─ embed_error (読み込み失敗)
+  │   └─ → ユーザーにリンク fallback が表示
+  └─ (埋め込み成功)
+      └─ reveal_open_external (一部ユーザーが外部クリック)
+
+quiz_complete (完走)
+  └─ quiz_complete × Completion Rate
+```
+
+---
+
+## 計測の実装責任
+
+| 指標 | 計測側 | 確認方法 |
+|------|--------|--------|
+| Completion Rate | FE (RevealCard, useAnswerProcessor) | quiz_complete イベント在無 |
+| Outbound Rate | FE (RevealCard.handleExternalClick) | reveal_open_external イベント在無 |
+| Embed Fallback Rate | FE (RevealCard useEffect) | embed_fallback_to_link イベント在無 |
+| Embed Load Error Rate | FE (RevealCard.handleEmbedError) | embed_error イベント在無 |
+
+**バックエンド責務**
+- `/v1/metrics` で全イベントを受け入れ、検証、D1 永続化
+- イベント日時・クライアント ID・属性の完全性を確保
+- 集計クエリを Grafana で実装
+
+---
+
+## ダッシュボード実装チェックリスト
+
+- [ ] Grafana Loki + Prometheus 設定完了
+- [ ] 日次イベント抽出 SQL / ETL パイプライン確立
+- [ ] Completion Rate 板 / グラフ作成
+- [ ] Outbound Rate 板 / グラフ作成（参考指標としてマーク）
+- [ ] Embed Fallback Rate 板 / グラフ作成
+- [ ] Embed Load Error Rate 板 / グラフ作成
+- [ ] Slack アラート統合（閾値超過時に #vgm-ops へ通知）
+- [ ] 週次レビュー議事録テンプレート用意
+
+---
+
+## 今後の拡張（Phase 4+）
+
+- Score Distribution（正解率別の分布）
+- Filter Effectiveness（フィルタ別完走率）
+- Time to Completion（セッション継続時間）
+- Provider Preference（ユーザーが選ぶプロバイダの嗜好）
+- A/B Test Metrics（UI 改善の効果測定）
+
+---
+
+## 関連ドキュメント
+
+- [quality/measurement-plan.md](measurement-plan.md) - イベント→指標マッピングと計測フロー
+- [ops/runbooks/audio-playback.md](../ops/runbooks/audio-playback.md) - Embed 失敗時の初動対応
+- [api/api-spec.md](../api/api-spec.md#post-v1metrics) - /v1/metrics エンドポイント仕様
+- [frontend/metrics-client.md](../frontend/metrics-client.md) - メトリクスクライアント実装
+
+---
+
+## 変更履歴
+
+- **2025-11-16**: Phase 3C 初版作成（Issue #32）

--- a/docs/quality/metrics.md
+++ b/docs/quality/metrics.md
@@ -130,7 +130,7 @@ Outbound Rate = reveal_open_external イベント数 / answer_result イベン�
 
 **計算式**
 ```
-Embed Fallback Rate = embed_fallback_to_link イベント数 / (reveal_view 数) × 100%
+Embed Fallback Rate = embed_fallback_to_link イベント数 / answer_result イベント数 × 100%
 ```
 
 **詳細**
@@ -138,7 +138,7 @@ Embed Fallback Rate = embed_fallback_to_link イベント数 / (reveal_view 数)
 | 項目 | 値 |
 |------|-----|
 | 分子 | `embed_fallback_to_link` イベント数（reason = 'no_embed_available'） |
-| 分母 | Reveal View 推定数（`quiz_complete` + `embed_error` + `embed_fallback_to_link`） |
+| 分母 | Reveal 表示回数の代理: `answer_result` イベント数（設問ごとに必ず 1 回送信） |
 | 集計粒度 | 日次、提供元別（provider: youtube/spotify/appleMusic） |
 | 計測期間 | 7 日（週次レビュー） |
 
@@ -149,7 +149,8 @@ Embed Fallback Rate = embed_fallback_to_link イベント数 / (reveal_view 数)
 - 原因: URL が youtube.com/watch?v=<ID> または youtu.be/<ID> 形式でない、または URL パース失敗
 
 **分母の定義**
-- **Reveal View**: [Outbound Rate](#outbound-rate--外部遷移率) と同じ代理イベント
+- イベント: `answer_result`（各設問で必ず送信され、直後に Reveal が表示される）
+- 集計: `COUNT(DISTINCT round_id || ':' || question_idx)`
 
 **目標値と閾値**
 

--- a/web/src/features/quiz/useAnswerProcessor.ts
+++ b/web/src/features/quiz/useAnswerProcessor.ts
@@ -14,6 +14,7 @@ import { TIMEOUT_CHOICE_ID, SKIP_CHOICE_ID, type PlayAction } from './playReduce
 import type { Outcome, ScoreBreakdown, QuestionRecord } from '@/src/lib/resultStorage';
 import type { Reveal } from './api/types';
 import type { ProgressInfo } from './playReducer';
+import { getInlinePlayback } from '@/src/lib/inlinePlayback';
 
 type AnswerMode = { kind: 'answer' | 'timeout' | 'skip'; choiceId?: string };
 
@@ -140,6 +141,8 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
         const updatedHistory = [...history, questionRecord];
         const updatedTally = rollupTally(tally, outcome, points);
 
+        const inlineEnabled = getInlinePlayback();
+
         recordMetricsEvent('answer_result', {
           roundId: continuationToken,
           questionIdx: progress?.index,
@@ -151,6 +154,7 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
             choiceId: questionRecord.choiceId,
             correctChoiceId: questionRecord.correctChoiceId,
             elapsedMs,
+            inlineEnabled,
           },
         });
 


### PR DESCRIPTION
## Summary
- add Phase 3C runbook for audio embeds and API security operations memo
- define KPI catalog in docs/quality/metrics.md with thresholds and notes for future providers
- document measurement plan with event->KPI mapping and D1-ready SQL examples

## Testing
- not run (docs only)
