### PR TITLE
feat: harden intake pipeline (#151)

### DIFF
--- a/workers/package.json
+++ b/workers/package.json
@@ -14,7 +14,8 @@
     "validate:curated": "tsx scripts/validate-curated.ts",
     "validate:facet-distribution": "tsx scripts/validate-facet-distribution.ts",
     "observability:test": "tsx scripts/observability-test.ts",
-    "export:snapshot": "tsx scripts/export-snapshot.ts"
+    "export:snapshot": "tsx scripts/export-snapshot.ts",
+    "promote:batch": "tsx scripts/promote-batch.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.934.0",

--- a/workers/pipeline/src/index.ts
+++ b/workers/pipeline/src/index.ts
@@ -6,8 +6,8 @@ import {
 } from '../../shared/lib/observability'
 import type { Env } from '../../shared/types/env'
 import type { FilterOptions } from '../../shared/types/filters'
-import { handleIntake } from './stages/intake'
 import { handleDiscovery } from './stages/discovery'
+import { handleIntake } from './stages/intake'
 import { handlePublish } from './stages/publish'
 
 export default {

--- a/workers/pipeline/src/stages/intake.ts
+++ b/workers/pipeline/src/stages/intake.ts
@@ -1,6 +1,10 @@
-import { isObservabilityEnabled, logEvent, sendSlackNotification } from '../../../shared/lib/observability'
+import {
+  isObservabilityEnabled,
+  logEvent,
+  sendSlackNotification,
+} from '../../../shared/lib/observability'
 import type { Env } from '../../../shared/types/env'
-import { guardAndDedup, type Candidate } from './guard'
+import { type Candidate, guardAndDedup } from './guard'
 
 interface IntakeResult {
   success: boolean
@@ -19,6 +23,89 @@ interface SourceEntry {
   active?: boolean
 }
 
+const RETRY_DELAYS_MS = [0, 2 * 60_000, 4 * 60_000, 8 * 60_000]
+const tierPriority = { L1: 1, L2: 2, L3: 3 } as const
+type TierKey = keyof typeof tierPriority
+
+function getTierPriority(tier?: string): number {
+  if (!tier) return tierPriority.L3
+  if (tierPriority[tier as TierKey]) return tierPriority[tier as TierKey]
+  return tierPriority.L3
+}
+
+function toTierLabel(priority: number): string {
+  if (priority <= 1) return 'L1'
+  if (priority === 2) return 'L2'
+  return 'L3'
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isTransientIntakeError(error: unknown): error is { transient?: boolean; status?: number } {
+  return Boolean(error && typeof error === 'object' && (error as { transient?: boolean }).transient)
+}
+
+async function fetchWithRetry(
+  env: Env,
+  requestFactory: () => Promise<Response>,
+  opts: { label: string; source?: SourceEntry },
+): Promise<Response> {
+  let lastStatus: number | undefined
+  let lastError: unknown
+
+  for (let attempt = 0; attempt < RETRY_DELAYS_MS.length; attempt++) {
+    if (attempt > 0) await sleep(RETRY_DELAYS_MS[attempt])
+    try {
+      const res = await requestFactory()
+      if (res.ok) return res
+
+      lastStatus = res.status
+      const retriable = res.status === 429 || (res.status >= 500 && res.status < 600)
+      if (!retriable) {
+        throw new Error(`${opts.label} ${res.status}`)
+      }
+
+      logEvent(env, 'warn', {
+        event: 'intake.retry',
+        status: 'warn',
+        message: `${opts.label} retrying`,
+        fields: {
+          attempt: attempt + 1,
+          status: res.status,
+          source: opts.source?.id,
+          tier: opts.source?.tier,
+        },
+      })
+    } catch (error) {
+      lastError = error
+      logEvent(env, 'warn', {
+        event: 'intake.retry',
+        status: 'warn',
+        message: `${opts.label} retry on failure`,
+        fields: {
+          attempt: attempt + 1,
+          source: opts.source?.id,
+          tier: opts.source?.tier,
+          error: error instanceof Error ? error.message : 'unknown error',
+        },
+      })
+    }
+  }
+
+  const err = new Error(`Retry exhausted for ${opts.label}`) as Error & {
+    transient?: boolean
+    status?: number
+    attempts?: number
+  }
+  err.transient = true
+  err.status = lastStatus
+  err.attempts = RETRY_DELAYS_MS.length
+  err.cause = lastError
+  throw err
+}
+
 export async function handleIntake(env: Env): Promise<IntakeResult> {
   const enabled = env.INTAKE_ENABLED === 'true' || env.INTAKE_ENABLED === '1'
   if (!enabled) {
@@ -27,13 +114,20 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       status: 'success',
       message: 'Intake disabled (INTAKE_ENABLED not set)',
     })
-    return { success: true, skipped: true, sourcesProcessed: 0, candidatesDiscovered: 0, errors: [] }
+    return {
+      success: true,
+      skipped: true,
+      sourcesProcessed: 0,
+      candidatesDiscovered: 0,
+      errors: [],
+    }
   }
 
   const errors: string[] = []
   const stage = env.INTAKE_STAGE || 'staging'
   let sourcesProcessed = 0
   let candidatesDiscovered = 0
+  let allowedTierPriority: number = tierPriority.L3
 
   logEvent(env, 'info', {
     event: 'intake.start',
@@ -126,10 +220,21 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
   })
 
   for (const source of catalog) {
+    const sourcePriority = getTierPriority(source.tier)
+    if (sourcePriority > allowedTierPriority) {
+      logEvent(env, 'warn', {
+        event: 'intake.tier.skip',
+        status: 'warn',
+        message: 'Skipping source due to tier downgrade window',
+        fields: { source: source.name || source.id, tier: source.tier, allowedTierPriority },
+      })
+      continue
+    }
+
     if (source.provider === 'youtube' && source.kind === 'playlist') {
       if (!youtubeKey) continue
       try {
-        const { count, candidates } = await fetchYouTubePlaylistItems(source.id, youtubeKey)
+        const { count, candidates } = await fetchYouTubePlaylistItems(env, source, youtubeKey)
         const enriched = candidates.length
           ? await enrichYouTubeMeta(env, candidates, youtubeKey)
           : []
@@ -208,6 +313,24 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'unknown error'
         errors.push(`${source.id}: ${message}`)
+        if (isTransientIntakeError(error)) {
+          const nextAllowed = Math.max(1, sourcePriority - 1)
+          if (nextAllowed < allowedTierPriority) {
+            const prev = allowedTierPriority
+            allowedTierPriority = nextAllowed
+            logEvent(env, 'warn', {
+              event: 'intake.tier.downgrade',
+              status: 'warn',
+              message: 'Transient error; downgrading remaining sources',
+              fields: {
+                source: source.name || source.id,
+                from: toTierLabel(prev),
+                to: toTierLabel(allowedTierPriority),
+                reason: message,
+              },
+            })
+          }
+        }
         logEvent(env, 'error', {
           event: 'intake.discovery',
           status: 'fail',
@@ -231,7 +354,8 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       }
       try {
         const { count, candidates } = await fetchSpotifyPlaylistItems(
-          source.id,
+          env,
+          source,
           spotifyId,
           spotifySecret,
         )
@@ -244,8 +368,7 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
           })
           continue
         }
-        const guardResult =
-          candidates.length > 0 ? await guardAndDedup(env, candidates) : undefined
+        const guardResult = candidates.length > 0 ? await guardAndDedup(env, candidates) : undefined
 
         if (evalProd && candidates.length > 0) {
           const prodResult = await guardAndDedup(env, candidates, 'production')
@@ -283,6 +406,24 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'unknown error'
         errors.push(`${source.id}: ${message}`)
+        if (isTransientIntakeError(error)) {
+          const nextAllowed = Math.max(1, sourcePriority - 1)
+          if (nextAllowed < allowedTierPriority) {
+            const prev = allowedTierPriority
+            allowedTierPriority = nextAllowed
+            logEvent(env, 'warn', {
+              event: 'intake.tier.downgrade',
+              status: 'warn',
+              message: 'Transient error; downgrading remaining sources',
+              fields: {
+                source: source.name || source.id,
+                from: toTierLabel(prev),
+                to: toTierLabel(allowedTierPriority),
+                reason: message,
+              },
+            })
+          }
+        }
         logEvent(env, 'error', {
           event: 'intake.discovery',
           status: 'fail',
@@ -305,12 +446,12 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       }
       try {
         const { count, candidates } = await fetchApplePlaylistItems(
-          source.id,
+          env,
+          source,
           appleToken,
           appleStorefront,
         )
-        const guardResult =
-          candidates.length > 0 ? await guardAndDedup(env, candidates) : undefined
+        const guardResult = candidates.length > 0 ? await guardAndDedup(env, candidates) : undefined
 
         sourcesProcessed += 1
         candidatesDiscovered += count
@@ -333,6 +474,24 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'unknown error'
         errors.push(`${source.id}: ${message}`)
+        if (isTransientIntakeError(error)) {
+          const nextAllowed = Math.max(1, sourcePriority - 1)
+          if (nextAllowed < allowedTierPriority) {
+            const prev = allowedTierPriority
+            allowedTierPriority = nextAllowed
+            logEvent(env, 'warn', {
+              event: 'intake.tier.downgrade',
+              status: 'warn',
+              message: 'Transient error; downgrading remaining sources',
+              fields: {
+                source: source.name || source.id,
+                from: toTierLabel(prev),
+                to: toTierLabel(allowedTierPriority),
+                reason: message,
+              },
+            })
+          }
+        }
         logEvent(env, 'error', {
           event: 'intake.discovery',
           status: 'fail',
@@ -355,7 +514,8 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       }
       try {
         const { count, candidates } = await fetchSpotifyArtistTopTracks(
-          source.id,
+          env,
+          source,
           spotifyId,
           spotifySecret,
           spotifyMarket,
@@ -415,6 +575,24 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'unknown error'
         errors.push(`${source.id}: ${message}`)
+        if (isTransientIntakeError(error)) {
+          const nextAllowed = Math.max(1, sourcePriority - 1)
+          if (nextAllowed < allowedTierPriority) {
+            const prev = allowedTierPriority
+            allowedTierPriority = nextAllowed
+            logEvent(env, 'warn', {
+              event: 'intake.tier.downgrade',
+              status: 'warn',
+              message: 'Transient error; downgrading remaining sources',
+              fields: {
+                source: source.name || source.id,
+                from: toTierLabel(prev),
+                to: toTierLabel(allowedTierPriority),
+                reason: message,
+              },
+            })
+          }
+        }
         logEvent(env, 'error', {
           event: 'intake.discovery',
           status: 'fail',
@@ -447,7 +625,8 @@ export async function handleIntake(env: Env): Promise<IntakeResult> {
 }
 
 async function fetchYouTubePlaylistItems(
-  playlistId: string,
+  env: Env,
+  source: SourceEntry,
   apiKey: string,
 ): Promise<{ count: number; candidates: Candidate[] }> {
   let total = 0
@@ -459,15 +638,14 @@ async function fetchYouTubePlaylistItems(
     const url = new URL('https://www.googleapis.com/youtube/v3/playlistItems')
     url.searchParams.set('part', 'snippet')
     url.searchParams.set('maxResults', '50')
-    url.searchParams.set('playlistId', playlistId)
+    url.searchParams.set('playlistId', source.id)
     url.searchParams.set('key', apiKey)
     if (pageToken) url.searchParams.set('pageToken', pageToken)
 
-    const res = await fetch(url.toString())
-    if (!res.ok) {
-      const body = await res.text()
-      throw new Error(`YouTube API ${res.status}: ${body.slice(0, 200)}`)
-    }
+    const res = await fetchWithRetry(env, () => fetch(url.toString()), {
+      label: 'youtube.playlistItems',
+      source,
+    })
 
     const data = (await res.json()) as {
       nextPageToken?: string
@@ -479,7 +657,16 @@ async function fetchYouTubePlaylistItems(
 
     for (const item of items) {
       if (!item || typeof item !== 'object') continue
-      const snippet = (item as any).snippet
+      const snippet = (
+        item as {
+          snippet?: {
+            title?: string
+            resourceId?: { videoId?: string }
+            videoOwnerChannelTitle?: string
+            channelTitle?: string
+          }
+        }
+      ).snippet
       const title = snippet?.title as string | undefined
       const videoId = snippet?.resourceId?.videoId as string | undefined
       const channelTitle =
@@ -501,24 +688,27 @@ async function fetchYouTubePlaylistItems(
 }
 
 async function fetchSpotifyPlaylistItems(
-  playlistId: string,
+  env: Env,
+  source: SourceEntry,
   clientId: string,
   clientSecret: string,
 ): Promise<{ count: number; candidates: Candidate[] }> {
-  const token = await getSpotifyToken(clientId, clientSecret)
+  const token = await getSpotifyToken(env, clientId, clientSecret, source)
   const candidates: Candidate[] = []
-  let next: string | null = `https://api.spotify.com/v1/playlists/${playlistId}/tracks?fields=items(track(id,name,artists(name),album(name),duration_ms,external_urls,external_ids,is_local)),next,limit,offset,total&limit=100`
+  let next: string | null =
+    `https://api.spotify.com/v1/playlists/${source.id}/tracks?fields=items(track(id,name,artists(name),album(name),duration_ms,external_urls,external_ids,is_local)),next,limit,offset,total&limit=100`
   let total = 0
   let safeguards = 0
 
   while (next && safeguards < 5) {
-    const res = await fetch(next, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    if (!res.ok) {
-      const body = await res.text()
-      throw new Error(`Spotify API ${res.status}: ${body.slice(0, 200)}`)
-    }
+    const res = await fetchWithRetry(
+      env,
+      () =>
+        fetch(next as string, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      { label: 'spotify.playlist', source },
+    )
     const data = (await res.json()) as {
       items?: Array<{
         track?: {
@@ -561,22 +751,24 @@ async function fetchSpotifyPlaylistItems(
 }
 
 async function fetchSpotifyArtistTopTracks(
-  artistId: string,
+  env: Env,
+  source: SourceEntry,
   clientId: string,
   clientSecret: string,
   market: string,
 ): Promise<{ count: number; candidates: Candidate[] }> {
-  const token = await getSpotifyToken(clientId, clientSecret)
-  const url = `https://api.spotify.com/v1/artists/${artistId}/top-tracks?market=${encodeURIComponent(
+  const token = await getSpotifyToken(env, clientId, clientSecret, source)
+  const url = `https://api.spotify.com/v1/artists/${source.id}/top-tracks?market=${encodeURIComponent(
     market,
   )}`
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`Spotify API ${res.status}: ${body.slice(0, 200)}`)
-  }
+  const res = await fetchWithRetry(
+    env,
+    () =>
+      fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    { label: 'spotify.artist_top_tracks', source },
+  )
   const data = (await res.json()) as {
     tracks?: Array<{
       id?: string
@@ -606,21 +798,27 @@ async function fetchSpotifyArtistTopTracks(
   return { count: tracks.length, candidates }
 }
 
-async function getSpotifyToken(clientId: string, clientSecret: string): Promise<string> {
+async function getSpotifyToken(
+  env: Env,
+  clientId: string,
+  clientSecret: string,
+  source?: SourceEntry,
+): Promise<string> {
   const body = new URLSearchParams()
   body.set('grant_type', 'client_credentials')
-  const res = await fetch('https://accounts.spotify.com/api/token', {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: body.toString(),
-  })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`Spotify token failed ${res.status}: ${text.slice(0, 200)}`)
-  }
+  const res = await fetchWithRetry(
+    env,
+    () =>
+      fetch('https://accounts.spotify.com/api/token', {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      }),
+    { label: 'spotify.token', source },
+  )
   const data = (await res.json()) as { access_token: string }
   if (!data.access_token) {
     throw new Error('Spotify token response missing access_token')
@@ -629,24 +827,23 @@ async function getSpotifyToken(clientId: string, clientSecret: string): Promise<
 }
 
 async function fetchApplePlaylistItems(
-  playlistId: string,
+  env: Env,
+  source: SourceEntry,
   token: string,
   storefront: string,
 ): Promise<{ count: number; candidates: Candidate[] }> {
   // playlistId expects the Apple Music catalog id (e.g., pl.12345)
-  const url = new URL(
-    `https://api.music.apple.com/v1/catalog/${storefront}/playlists/${playlistId}`,
-  )
+  const url = new URL(`https://api.music.apple.com/v1/catalog/${storefront}/playlists/${source.id}`)
   url.searchParams.set('include', 'tracks')
 
-  const res = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`Apple Music API ${res.status}: ${body.slice(0, 200)}`)
-  }
+  const res = await fetchWithRetry(
+    env,
+    () =>
+      fetch(url.toString(), {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    { label: 'apple.playlist', source },
+  )
 
   const data = (await res.json()) as {
     data?: Array<{
@@ -697,8 +894,7 @@ async function maybeAlertOnRates(
   const guardFailRate = guardResult.stats.guardFail / total
   const duplicateRate = guardResult.stats.duplicates / total
 
-  const warn =
-    guardFailRate >= 0.2 || duplicateRate >= 0.2
+  const warn = guardFailRate >= 0.2 || duplicateRate >= 0.2
 
   if (!warn) return
 
@@ -729,13 +925,23 @@ async function enrichYouTubeMeta(
     url.searchParams.set('id', chunk.join(','))
     url.searchParams.set('key', apiKey)
 
-    const res = await fetch(url.toString())
-    if (!res.ok) {
-      const body = await res.text()
+    let res: Response
+    try {
+      res = await fetchWithRetry(env, () => fetch(url.toString()), {
+        label: 'youtube.videos',
+        source: {
+          id: chunk.join(','),
+          provider: 'youtube',
+          kind: 'playlist',
+          tier: 'L1',
+        } as SourceEntry,
+      })
+    } catch (error) {
       logEvent(env, 'warn', {
         event: 'intake.youtube.enrich',
         status: 'fail',
-        message: `YouTube videos API ${res.status}: ${body.slice(0, 120)}`,
+        message: 'YouTube videos API retry exhausted',
+        error,
       })
       continue
     }
@@ -765,11 +971,12 @@ async function enrichYouTubeMeta(
 
 function iso8601DurationToSeconds(duration: string): number | undefined {
   // Simple parser for PT#H#M#S
-  const match =
-    /P(?:\d+Y)?(?:\d+M)?(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?/.exec(duration)
+  const match = /P(?:\d+Y)?(?:\d+M)?(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?/.exec(
+    duration,
+  )
   if (!match) return undefined
-  const hours = match[1] ? parseInt(match[1], 10) : 0
-  const minutes = match[2] ? parseInt(match[2], 10) : 0
-  const seconds = match[3] ? parseFloat(match[3]) : 0
+  const hours = match[1] ? Number.parseInt(match[1], 10) : 0
+  const minutes = match[2] ? Number.parseInt(match[2], 10) : 0
+  const seconds = match[3] ? Number.parseFloat(match[3]) : 0
   return hours * 3600 + minutes * 60 + seconds
 }

--- a/workers/pipeline/src/stages/intake.ts
+++ b/workers/pipeline/src/stages/intake.ts
@@ -92,6 +92,10 @@ async function fetchWithRetry(
       const status = (error as { status?: number }).status
       if (status !== undefined) lastStatus = status
       lastRetriable = isRetriableStatus(status) || error instanceof TypeError
+      if (!lastRetriable) {
+        // Non-retriable: surface immediately to stop backoff loop
+        throw error
+      }
       logEvent(env, 'warn', {
         event: 'intake.retry',
         status: 'warn',

--- a/workers/pipeline/src/stages/publish.ts
+++ b/workers/pipeline/src/stages/publish.ts
@@ -315,8 +315,7 @@ export async function handlePublish(
       status: 'success',
       filtersKey: filterKey,
       r2Key,
-      hash,
-      fields: { date, questionsGenerated: questions.length },
+      fields: { date, questionsGenerated: questions.length, hash },
     })
 
     return {

--- a/workers/scripts/export-snapshot.ts
+++ b/workers/scripts/export-snapshot.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import {
   CopyObjectCommand,
   HeadObjectCommand,
@@ -304,7 +305,9 @@ async function main(): Promise<void> {
   }
 }
 
-if (import.meta.main) {
+const isMain = process.argv[1] === fileURLToPath(import.meta.url)
+
+if (isMain) {
   main().catch((error) => {
     console.error('[fatal] export-snapshot failed:', error)
     process.exit(1)

--- a/workers/scripts/promote-batch.ts
+++ b/workers/scripts/promote-batch.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Promote a staging export batch to production R2/D1.
+ *
+ * Prerequisites:
+ * - R2 credentials: CLOUDFLARE_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
+ * - Buckets: R2_SOURCE_BUCKET (staging), R2_TARGET_BUCKET (production)
+ * - Optional: SOURCE_PREFIX (e.g. "staging"), TARGET_PREFIX (e.g. "")
+ * - Date is required; batchId defaults to `${date}-<timestamp>`
+ *
+ * This script copies the export object, tags it with batchId metadata,
+ * and writes a SQL file for D1 promotion / rollback.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { Readable } from 'node:stream'
+import { CopyObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { CANONICAL_FILTER_KEY, buildExportR2Key } from '../shared/lib/filters'
+
+interface Args {
+  date: string
+  batchId: string
+  filterKey: string
+  dryRun: boolean
+  sourcePrefix?: string
+  targetPrefix?: string
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Partial<Args> = {}
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--date' || arg === '-d') {
+      args.date = argv[++i]
+    } else if (arg === '--batch' || arg === '-b') {
+      args.batchId = argv[++i]
+    } else if (arg === '--filter-key' || arg === '-f') {
+      args.filterKey = argv[++i]
+    } else if (arg === '--source-prefix') {
+      args.sourcePrefix = argv[++i]
+    } else if (arg === '--target-prefix') {
+      args.targetPrefix = argv[++i]
+    } else if (arg === '--dry-run') {
+      args.dryRun = true
+    }
+  }
+
+  if (!args.date) {
+    throw new Error('Missing required --date (YYYY-MM-DD)')
+  }
+
+  return {
+    date: args.date,
+    batchId: args.batchId || `${args.date}-${Date.now()}`,
+    filterKey: args.filterKey || CANONICAL_FILTER_KEY,
+    dryRun: args.dryRun ?? false,
+    sourcePrefix: args.sourcePrefix,
+    targetPrefix: args.targetPrefix,
+  }
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`)
+  }
+  return value
+}
+
+function joinKey(prefix: string | undefined, key: string): string {
+  if (!prefix) return key
+  const p = prefix.replace(/\/+$/, '')
+  return `${p}/${key}`
+}
+
+function escapeSqlLiteral(value: string): string {
+  return value.replace(/'/g, "''")
+}
+
+async function streamToString(body: unknown): Promise<string> {
+  if (!body) return ''
+  if (typeof body === 'string') return body
+  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf-8')
+  if (body instanceof Readable) {
+    const chunks: Buffer[] = []
+    for await (const chunk of body) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk))
+    }
+    return Buffer.concat(chunks).toString('utf-8')
+  }
+  const bodyMaybeTransform = body as {
+    transformToByteArray?: () => Promise<Uint8Array> | Uint8Array
+  }
+  if (typeof bodyMaybeTransform.transformToByteArray === 'function') {
+    const bytes = await bodyMaybeTransform.transformToByteArray()
+    return Buffer.from(bytes).toString('utf-8')
+  }
+  return ''
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv)
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID')
+  const sourceBucket = requireEnv('R2_SOURCE_BUCKET')
+  const targetBucket = requireEnv('R2_TARGET_BUCKET')
+  const accessKeyId = requireEnv('R2_ACCESS_KEY_ID')
+  const secretAccessKey = requireEnv('R2_SECRET_ACCESS_KEY')
+
+  const baseKey = buildExportR2Key(args.date, args.filterKey)
+  const sourceKey = joinKey(args.sourcePrefix || 'staging', baseKey)
+  const targetKey = joinKey(args.targetPrefix, baseKey)
+
+  const endpoint = `https://${accountId}.r2.cloudflarestorage.com`
+  const s3 = new S3Client({
+    region: 'auto',
+    endpoint,
+    credentials: { accessKeyId, secretAccessKey },
+  })
+
+  if (args.dryRun) {
+    console.log(
+      '[dry-run] would copy',
+      `${sourceBucket}/${sourceKey}`,
+      '->',
+      `${targetBucket}/${targetKey}`,
+    )
+  } else {
+    await s3.send(
+      new CopyObjectCommand({
+        Bucket: targetBucket,
+        CopySource: `/${sourceBucket}/${sourceKey}`,
+        Key: targetKey,
+        Metadata: { batchId: args.batchId },
+        MetadataDirective: 'REPLACE',
+        ContentType: 'application/json',
+      }),
+    )
+    console.log('Copied R2 object with batchId metadata', { targetKey })
+  }
+
+  const object = await s3.send(
+    new GetObjectCommand({
+      Bucket: args.dryRun ? sourceBucket : targetBucket,
+      Key: args.dryRun ? sourceKey : targetKey,
+    }),
+  )
+
+  const body = await streamToString(object.Body)
+  const parsed = JSON.parse(body) as {
+    meta?: { hash?: string; version?: string }
+  }
+  const hash = parsed.meta?.hash || ''
+  const version = parsed.meta?.version || '1.0.0'
+
+  const sql = [
+    '-- Auto-generated promotion script',
+    'BEGIN TRANSACTION;',
+    'CREATE TABLE IF NOT EXISTS promotion_batches (',
+    '  batch_id TEXT PRIMARY KEY,',
+    '  date TEXT NOT NULL,',
+    '  r2_key TEXT NOT NULL,',
+    '  filter_key TEXT NOT NULL,',
+    "  created_at INTEGER DEFAULT (strftime('%s','now'))",
+    ');',
+    `INSERT OR REPLACE INTO promotion_batches (batch_id, date, r2_key, filter_key) VALUES ('${escapeSqlLiteral(args.batchId)}', '${escapeSqlLiteral(args.date)}', '${escapeSqlLiteral(targetKey)}', '${escapeSqlLiteral(args.filterKey)}');`,
+    `INSERT OR REPLACE INTO picks (date, items, status, filters_json) VALUES ('${escapeSqlLiteral(args.date)}', '${escapeSqlLiteral(body)}', 'published', '${escapeSqlLiteral(args.filterKey)}');`,
+    `INSERT OR REPLACE INTO exports (date, r2_key, version, hash, filters_json) VALUES ('${escapeSqlLiteral(args.date)}', '${escapeSqlLiteral(targetKey)}', '${escapeSqlLiteral(version)}', '${escapeSqlLiteral(hash)}', '${escapeSqlLiteral(args.filterKey)}');`,
+    'COMMIT;',
+    '',
+    '-- Rollback template',
+    `-- DELETE FROM exports WHERE date='${escapeSqlLiteral(args.date)}' AND filters_json='${escapeSqlLiteral(args.filterKey)}';`,
+    `-- DELETE FROM picks WHERE date='${escapeSqlLiteral(args.date)}' AND filters_json='${escapeSqlLiteral(args.filterKey)}';`,
+    `-- DELETE FROM promotion_batches WHERE batch_id='${escapeSqlLiteral(args.batchId)}';`,
+    '',
+  ].join('\n')
+
+  const outDir = path.join(process.cwd(), 'tmp')
+  await mkdir(outDir, { recursive: true })
+  const outPath = path.join(outDir, `batch-${args.batchId}.sql`)
+  await writeFile(outPath, sql, 'utf8')
+
+  console.log('Promotion SQL written to', outPath)
+  console.log('Apply with: wrangler d1 execute <DB_NAME> --file', outPath)
+  if (args.dryRun) {
+    console.log('Note: dry-run only generated SQL; no R2 copy performed.')
+  }
+}
+
+main().catch((err) => {
+  console.error('[promote-batch] failed', err)
+  process.exit(1)
+})

--- a/workers/tests/api-daily.spec.ts
+++ b/workers/tests/api-daily.spec.ts
@@ -4,6 +4,7 @@ import { fetchBackupDaily } from '../api/src/lib/daily'
 import { handleDailyRequest } from '../api/src/routes/daily'
 import * as observability from '../shared/lib/observability'
 import type { Env } from '../shared/types/env'
+import type { DailyExport } from '../shared/types/export'
 import { InMemoryR2Bucket } from './helpers/in-memory-r2'
 
 class EmptyStatement {
@@ -77,7 +78,7 @@ describe('daily backup retrieval', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('X-VGM-Daily-Source')).toBe('backup')
 
-    const payload = await response.json()
+    const payload = (await response.json()) as DailyExport
     expect(payload.meta.date).toBe('2025-01-02')
     expect(payload.meta.hash).toBe('hash-2')
   })


### PR DESCRIPTION
## Summary
- enforce audio guard warnings, retry/backoff, and tier downgrade for intake
- add fuzzy dedup grouping to cut near-duplicate noise; log duplicate/warn details
- add batch promotion CLI and doc/runbook updates for Phase 4A

## Testing
- npm run lint --workspace workers
- npm run typecheck --workspace workers
- wrangler dev --test-scheduled with YouTube+Spotify catalog (staging/prod eval)