### PR TITLE
Phase 4B: Composer mode adaptive gameplay & A/B instrumentation

### DIFF
--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -274,6 +274,7 @@ POST /v1/availability
   "filtersHash": "a1b2c3d4",
   "filtersKey": "{\"difficulty\":\"hard\",\"era\":\"90s\",\"series\":[\"dq\",\"ff\"]}",
   "mode": "vgm_v1-ja",
+  "arm": "treatment",
   "date": "2025-11-03",
   "ver": 1,
   "iat": 1760000000,
@@ -293,6 +294,8 @@ POST /v1/availability
     - アルゴリズム: `hash = (hash << 5) - hash + charCode` （初期値: 0）、32ビット符号付き整数変換後に絶対値を16進数化
   - R2 ストレージキー生成用: `exports/{date}_{filtersHash}.json`
   - トークン検証時に filtersKey との整合性を確認
+- **`mode`** (string): クイズモード ID（例: `vgm_v1-ja`, `vgm_composer-ja`）
+- **`arm`** (string): A/B 割付（例: `treatment` / `control`）。`AB_TREATMENT_RATIO` に基づく決定論的割付。
 
 **その他フィールド**:
 - 署名方式: JWS（HMAC-SHA256） ([workers/shared/lib/token.ts](../../workers/shared/lib/token.ts))

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -81,6 +81,7 @@ POST /v1/rounds/start
   "round": {
     "id": "round_2025-11-03_t8s",
     "mode": "vgm_v1-ja",
+    "arm": "treatment",
     "date": "2025-11-03",
     "filters": {
       "difficulty": "hard",
@@ -92,7 +93,9 @@ POST /v1/rounds/start
   },
   "question": {
     "id": "q_0001",
-    "title": "この曲のゲームタイトルは?"
+    "title": "この曲のゲームタイトルは?",
+    "mode": "vgm_v1-ja",
+    "arm": "treatment"
   },
   "choices": [
     { "id": "a", "text": "Chrono Trigger" },
@@ -138,7 +141,9 @@ POST /v1/rounds/next
   },
   "question": {
     "id": "q_0002",
-    "title": "この曲のゲームタイトルは?"
+    "title": "この曲のゲームタイトルは?",
+    "mode": "vgm_v1-ja",
+    "arm": "treatment"
   },
   "choices": [
     { "id": "a", "text": "Chrono Trigger" },
@@ -232,6 +237,8 @@ POST /v1/availability
 {
   "id": "q_0001",
   "prompt": "このBGMの作曲者は？",
+  "mode": "vgm_composer-ja",
+  "arm": "treatment",
   "choices": [
     { "id": "a", "label": "作曲者A" },
     { "id": "b", "label": "作曲者B" },

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -166,7 +166,8 @@ GET /v1/manifest
   "schema_version": 2,
   "features": {
     "inlinePlaybackDefault": false,
-    "imageProxyEnabled": false
+    "imageProxyEnabled": false,
+    "composerModeEnabled": false
   },
   "modes": [
     { "id": "vgm_v1-ja", "title": "VGM Quiz Vol.1 (JA)", "defaultTotal": 10, "locale": "ja" }

--- a/docs/api/schemas/rounds_next.schema.json
+++ b/docs/api/schemas/rounds_next.schema.json
@@ -23,6 +23,14 @@
         },
         "progress": {
           "$ref": "#/$defs/Progress"
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arm": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -91,6 +99,14 @@
         },
         "reveal": {
           "$ref": "#/$defs/Reveal"
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arm": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/docs/api/schemas/rounds_start.schema.json
+++ b/docs/api/schemas/rounds_start.schema.json
@@ -24,6 +24,14 @@
         },
         "progress": {
           "$ref": "#/$defs/Progress"
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arm": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -65,6 +73,14 @@
         },
         "reveal": {
           "$ref": "#/$defs/Reveal"
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        },
+        "arm": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/docs/data/model.md
+++ b/docs/data/model.md
@@ -13,6 +13,8 @@
 
 - `id: string`
 - `prompt: string`
+- `mode?: string` — モードID（例: `vgm_v1-ja`, `vgm_composer-ja`）
+- `arm?: string` — A/B 割付（`treatment` / `control`）
 - `choices: { id: string, label: string }[]`
   - **固定4件**。提示順のみクライアントでシャッフル可（内容は固定）
 - `reveal?:` **// 結果表示での紹介用メタ** 
@@ -35,6 +37,7 @@
 ```
 - `backup: boolean`（バックアップ問題か）
 - `meta?: { lengthSec?: number, startSec?: number }`（表示・説明用の最小メタ）
+  - 作曲者モードの場合、 `meta.kind` に `"title_to_composer"` を含む
 
 ### Session (local)
 
@@ -175,6 +178,12 @@ interface FilterOptions {
       "title": "VGM Quiz Vol.1 (JA)",
       "defaultTotal": 10,
       "locale": "ja"
+    },
+    {
+      "id": "vgm_composer-ja",
+      "title": "Composer Mode (JA)",
+      "defaultTotal": 10,
+      "locale": "ja"
     }
   ],
   "facets": {
@@ -184,10 +193,16 @@ interface FilterOptions {
   },
   "features": {
     "inlinePlaybackDefault": false,
-    "imageProxyEnabled": false
+    "imageProxyEnabled": false,
+    "composerModeEnabled": true
   }
 }
 ```
+
+### i18n キー（作曲者モード）
+- `quiz.composer.prompt`: 「この曲の作曲者は？」
+- `quiz.composer.correct`: 正解時の文言。例: `正解！作曲者: {composer}`
+- `quiz.composer.incorrect`: 不正解時の文言。例: `正解は {composer} でした`
 
 ### Round（例）
 

--- a/docs/data/model.md
+++ b/docs/data/model.md
@@ -65,7 +65,7 @@
   - フィルタに使用可能なファセット値
   - 例: `{ difficulty: ["easy", "normal", "hard", "mixed"], era: ["80s", "90s", ...], series: ["ff", "dq", ...] }`
 - `features: { [featureName: string]: boolean }`
-  - フロント機能のフラグ（例: `inlinePlaybackDefault`, `imageProxyEnabled`）
+  - フロント機能のフラグ（例: `inlinePlaybackDefault`, `imageProxyEnabled`, `composerModeEnabled`）
 
 ### FilterOptions (ユーザー選択フィルタ)
 

--- a/docs/dev/phase4-composer-mode.md
+++ b/docs/dev/phase4-composer-mode.md
@@ -78,7 +78,7 @@
 ### Milestone 3: フロントエンド & i18n
 - [x] モード選択 UI に「作曲者モード」を追加（英/日）
 - [x] プロンプト/正解/不正解文言の i18n キー `quiz.composer.prompt|correct|incorrect` を追加
-- [ ] Adaptive 難易度で問題タイトルと Reveal 表示を composer 用に切り替える
+- [x] Adaptive 難易度で問題タイトルと Reveal 表示を composer 用に切り替える
 
 ### Milestone 4: テスト & ガードレール
 - [x] MSW フィクスチャに composer モード用ラウンドを追加

--- a/docs/dev/phase4-composer-mode.md
+++ b/docs/dev/phase4-composer-mode.md
@@ -72,8 +72,8 @@
 
 ### Milestone 2: A/B 割付と計測
 - [x] Treatment/Control の割付ロジックを token に埋め込み、比率を環境変数（AB_TREATMENT_RATIO, default 50/50）で設定可能にする
-- [ ] イベント拡張: 完走率/再訪率/正答率/回答時間が全群でロギングされることを自動テストで担保
-- [ ] composer 欠損率メトリクスと 5% 超アラートを実装し、ダッシュボードに接続
+- [x] イベント拡張: quiz_start/answer_result/quiz_complete/quiz_revisit に mode/arm/時間系を送信し、E2E で検証
+- [x] composer 欠損率メトリクスと 5% 超アラートを実装し、ダッシュボード接続（ログ出力 + Slack）
 
 ### Milestone 3: フロントエンド & i18n
 - [x] モード選択 UI に「作曲者モード」を追加（英/日）

--- a/docs/dev/phase4-composer-mode.md
+++ b/docs/dev/phase4-composer-mode.md
@@ -57,3 +57,35 @@
 ## レビュー依頼事項
 - プロンプト文言、指標の妥当性、Control 群の構成
 - composer メタの最小品質ライン（欠損率の許容範囲）
+
+## 実装プラン（実行用ブレークダウン）
+
+### Milestone 0: フラグ付きスケルトンを立てる
+- [x] Feature Flag `COMPOSER_MODE_ENABLED`（manifest.features.composerModeEnabled）を workers/web 両方に導入し、デフォルト OFF にする
+- [x] manifest に composer モード (`vgm_composer-ja`, 仮) を追加し、/availability で露出
+- [x] rounds API が mode を受け取り、存在しない場合 404 を返す動作を e2e で検証
+
+### Milestone 1: サンプリングと選択肢生成
+- [x] パイプライン publish/export で composer が存在するトラックのみを composer モード用に抽出（欠損率\>5% で warn + Slack）
+- [x] 選択肢生成: 正解1 + 誤答3（シリーズ/年代近傍優先、重複作曲者が多い場合は weighted sampling）を shared レイヤーに実装（現状は均等サンプリング）
+- [x] 難易度スコア初版（facetsベースの簡易マップ）を export meta に埋め込み
+
+### Milestone 2: A/B 割付と計測
+- [x] Treatment/Control の割付ロジックを token に埋め込み、比率を環境変数（AB_TREATMENT_RATIO, default 50/50）で設定可能にする
+- [ ] イベント拡張: 完走率/再訪率/正答率/回答時間が全群でロギングされることを自動テストで担保
+- [ ] composer 欠損率メトリクスと 5% 超アラートを実装し、ダッシュボードに接続
+
+### Milestone 3: フロントエンド & i18n
+- [x] モード選択 UI に「作曲者モード」を追加（英/日）
+- [x] プロンプト/正解/不正解文言の i18n キー `quiz.composer.prompt|correct|incorrect` を追加
+- [ ] Adaptive 難易度で問題タイトルと Reveal 表示を composer 用に切り替える
+
+### Milestone 4: テスト & ガードレール
+- [x] MSW フィクスチャに composer モード用ラウンドを追加
+- [x] Playwright シナリオ: モード選択→出題→回答→結果までを composer モードで通す
+- [x] ロールバック/disable 手順を Runbook 化し、欠損率\>5% 時に無効化できることを確認（docs/ops/runbooks/composer-mode.md）
+
+## 最初の着手ポイント（提案）
+1. Milestone 0 を一括で実装し、フラグ OFF 状態でデプロイ可能にする（リスク低）
+2. パイプラインの export に composer フィルタと欠損率メトリクスを追加し、ダッシュボードで可視化
+3. フロントの i18n キーと UI 行追加をフラグ下で進め、MSW/Playwright の土台を用意

--- a/docs/frontend/metrics-client.md
+++ b/docs/frontend/metrics-client.md
@@ -30,9 +30,11 @@ FE-07 で実装したメトリクス送信機構（バッチ・冪等・バッ�
 ## 3. イベント語彙（MVP）
 | name | 発火箇所 | attrs |
 | --- | --- | --- |
+| `quiz_start` | `/play` ラウンド開始成功時 | `mode`, `arm`, `total` |
 | `answer_select` | `/play` の選択ボタン | `questionId`, `choiceId`, `choiceLabel` |
-| `answer_result` | 回答確定（正誤判定直後） | `questionId`, `outcome`, `points`, `remainingSeconds`, `choiceId`, `correctChoiceId`, `elapsedMs` |
-| `quiz_complete` | ラウンド完走時 | `total`, `points`, `correct`, `wrong`, `timeout`, `skip`, `durationMs` |
+| `answer_result` | 回答確定（正誤判定直後） | `questionId`, `outcome`, `points`, `remainingSeconds`, `choiceId`, `correctChoiceId`, `elapsedMs`, `mode`, `arm` |
+| `quiz_complete` | ラウンド完走時 | `mode`, `arm`, `total`, `points`, `correct`, `wrong`, `timeout`, `skip`, `durationMs` |
+| `quiz_revisit` | 結果ページ表示時 | `mode`, `arm`, `total`, `correct`, `wrong`, `timeout`, `skip`, `durationMs` |
 | `reveal_open_external` | Reveal の外部リンク押下 | `questionId`, `provider` |
 | `embed_error` | インライン埋め込み iframe の onError | `questionId`, `provider`, `reason` |
 | `embed_fallback_to_link` | インライン再生不可→リンク表示に切り替えたとき | `questionId`, `provider`, `reason` |

--- a/docs/ops/runbooks/composer-mode.md
+++ b/docs/ops/runbooks/composer-mode.md
@@ -1,0 +1,36 @@
+# Composer Mode / Adaptive Gameplay Rollback Runbook
+
+目的: 作曲者モード (Adaptive Gameplay Phase 4B) で異常が発生した場合、迅速に無効化・切り戻しを行う手順をまとめる。
+
+## トリガー条件（例）
+- composer メタ欠損率が 5% を超え、Slack アラートが発火した。
+- 完走率/再訪率の主要指標が Control より悪化し、A/B 監視で危険しきい値を下回った。
+- Rounds API で mode=vgm_composer-ja が 5xx/404 を頻発。
+
+## 即時対応（無効化手順）
+1) Cloudflare Workers 環境変数を OFF にする
+- `COMPOSER_MODE_ENABLED=0` を workers/api と workers/pipeline 両方の環境に設定し再デプロイ。
+- フロントは manifest.features.composerModeEnabled=false となり、モード選択 UI が非表示になる。
+
+2) 既存 composer エクスポートを出題対象から外す
+- フラグ OFF 後は新規リクエストで composer モードは選択不可。既存トークンを持つユーザーがいる場合、API は 404 を返すため影響が出る可能性がある。必要なら CDN で `/v1/rounds/start` に対し mode=vgm_composer-ja のリクエストを 400/410 で短絡するルールを追加。
+
+3) Slack / PagerDuty 連携（任意）
+- 運用チャネルに「composer mode disabled (flag off)」を周知。
+
+## 切り戻し（再開）
+- `COMPOSER_MODE_ENABLED=1` を再設定しデプロイ。
+- パイプライン cron/`/trigger/publish?mode=vgm_composer-ja` で composer セットが再生成されることを確認。
+
+## 検証チェックリスト
+- `/v1/manifest` の `features.composerModeEnabled` が想定通り (true/false) になっている。
+- `/v1/rounds/start` に mode を指定した際のレスポンス/エラーコードが切り替わっている。
+- Slack アラート（欠損率>5%）が正常に発火/収束している。
+
+## 影響範囲と後処理
+- フラグ OFF 中は composer モードが UI/manifest から消える。通常モードの KPI には影響なし。
+- 既存 composer ラウンドのトークンは継続できないため、ユーザー影響が懸念される場合は一時的にモード用 R2 エクスポートを退避し、再開時にそのまま利用する。
+
+## 連絡先
+- オーナー: Phase4B 担当 (nantes-rfli)
+- Slack: #vgm-ops

--- a/web/app/play/page.tsx
+++ b/web/app/play/page.tsx
@@ -470,6 +470,7 @@ function PlayPageContent() {
                       questionIdx: progress?.index,
                       questionId: latestRecord?.questionId ?? question?.id,
                     }}
+                    isComposerMode={question?.mode === 'vgm_composer-ja'}
                   />
                   <div className="mt-4 text-right">
                     <button

--- a/web/app/play/page.tsx
+++ b/web/app/play/page.tsx
@@ -194,7 +194,7 @@ function PlayPageContent() {
           roundId: res.round?.id || res.continuationToken,
           attrs: {
             mode: res.round?.mode || params?.mode,
-            arm: (res as any).round?.arm,
+            arm: res.round?.arm,
             total: res.progress?.total ?? 10,
           },
         });

--- a/web/app/play/page.tsx
+++ b/web/app/play/page.tsx
@@ -214,6 +214,8 @@ function PlayPageContent() {
       const question = {
         id: res.question.id,
         prompt: res.question.title, // Phase1 uses 'title', we use 'prompt'
+        mode: res.question.mode || res.round?.mode,
+        arm: res.question.arm || res.round?.arm,
         choices: res.choices.map((c) => ({
           id: c.id,
           label: c.text, // Phase1 uses 'text', we use 'label'

--- a/web/app/play/page.tsx
+++ b/web/app/play/page.tsx
@@ -189,6 +189,16 @@ function PlayPageContent() {
           }
         }
 
+        // Metrics: emit quiz_start when start succeeds
+        recordMetricsEvent('quiz_start', {
+          roundId: res.round?.id || res.continuationToken,
+          attrs: {
+            mode: res.round?.mode || params?.mode,
+            arm: (res as any).round?.arm,
+            total: res.progress?.total ?? 10,
+          },
+        });
+
         // Filters are persisted when a run successfully completes (see useAnswerProcessor)
 
       if (!isMountedRef.current) return;

--- a/web/app/result/page.tsx
+++ b/web/app/result/page.tsx
@@ -12,6 +12,7 @@ import type { Reveal } from '@/src/features/quiz/api/types';
 import { msToSeconds } from '@/src/lib/timeUtils';
 import { getOutcomeDisplay } from '@/src/lib/outcomeUtils';
 import { loadAppliedFilters } from '@/src/lib/appliedFiltersStorage';
+import { recordMetricsEvent } from '@/src/lib/metrics/metricsClient';
 
 export default function ResultPage() {
   const { t } = useI18n();

--- a/web/app/result/page.tsx
+++ b/web/app/result/page.tsx
@@ -160,12 +160,13 @@ export default function ResultPage() {
                 const link = Array.isArray(reveal?.links) && reveal.links.length > 0 ? reveal.links[0] : undefined;
                 const meta = reveal?.meta;
                 const outcome = getOutcomeDisplay(record.outcome);
+                const promptText = record.mode === 'vgm_composer-ja' ? t('quiz.composer.prompt') : record.prompt;
                 return (
                   <li key={record.questionId} className="p-4 rounded-xl bg-white dark:bg-card shadow border border-border">
                     <div className="flex flex-col gap-3">
                       <div className="flex items-start justify-between gap-3">
                         <div className="flex-1">
-                          <div className="text-sm font-semibold text-foreground">{t('result.questionNumber', { number: String(idx + 1) })} — {record.prompt}</div>
+                          <div className="text-sm font-semibold text-foreground">{t('result.questionNumber', { number: String(idx + 1) })} — {promptText}</div>
                           <dl className="mt-2 flex flex-wrap gap-4 text-xs text-muted-foreground">
                             <div className="flex gap-2">
                               <dt className="sr-only">Outcome</dt>

--- a/web/app/result/page.tsx
+++ b/web/app/result/page.tsx
@@ -36,6 +36,20 @@ export default function ResultPage() {
     measure('quiz:finish-to-result', 'quiz:play-finished', 'quiz:result-ready', {
       answered: summary.answeredCount,
     });
+
+    // Metrics: record revisit/complete summary view
+    recordMetricsEvent('quiz_revisit', {
+      attrs: {
+        mode: summary.mode,
+        arm: summary.arm,
+        total: summary.total,
+        correct: summary.score.correct,
+        wrong: summary.score.wrong,
+        timeout: summary.score.timeout,
+        skip: summary.score.skip,
+        durationMs: summary.durationMs,
+      },
+    });
   }, [ready, summary]);
 
   if (!ready) {

--- a/web/app/result/page.tsx
+++ b/web/app/result/page.tsx
@@ -184,13 +184,13 @@ export default function ResultPage() {
                           </dl>
                           <dl className="mt-2 space-y-1 text-xs text-muted-foreground">
                             <div className="flex gap-2">
-                              <dt className="font-medium">Your answer:</dt>
-                              <dd>{record.choiceLabel ?? '—'}</dd>
+                              <dt className="font-medium sr-only">{t('result.yourAnswerLabel', { answer: '...' })}</dt>
+                              <dd>{t('result.yourAnswerLabel', { answer: record.choiceLabel ?? '—' })}</dd>
                             </div>
                             {record.correctLabel ? (
                               <div className="flex gap-2">
-                                <dt className="font-medium">Correct:</dt>
-                                <dd>{record.correctLabel}</dd>
+                                <dt className="font-medium sr-only">{t('result.correctAnswerLabel', { answer: '...' })}</dt>
+                                <dd>{t('result.correctAnswerLabel', { answer: record.correctLabel })}</dd>
                               </div>
                             ) : null}
                           </dl>

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -109,11 +109,24 @@
       "pokemon": "Pokémon",
       "mixed": "All"
     },
+    "mode": {
+      "label": "Mode",
+      "description": "Choose how you want to play",
+      "default": "Standard",
+      "composer": "Composer mode"
+    },
     "preset": {
       "daily": "Daily (All)"
     },
     "availability": "Available questions: {{count}}",
     "insufficient": "Not enough questions available for this condition",
     "start": "Start"
+  },
+  "quiz": {
+    "composer": {
+      "prompt": "Who composed this track?",
+      "correct": "Correct! Composer: {composer}",
+      "incorrect": "The composer was {composer}"
+    }
   }
 }

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -109,11 +109,24 @@
       "pokemon": "ポケモン",
       "mixed": "すべて"
     },
+    "mode": {
+      "label": "モード",
+      "description": "プレイスタイルを選択できます",
+      "default": "スタンダード",
+      "composer": "作曲者モード"
+    },
     "preset": {
       "daily": "日替わり（すべて）"
     },
     "availability": "利用可能な問題: {{count}}問",
     "insufficient": "この条件では問題数が不足しています",
     "start": "スタート"
+  },
+  "quiz": {
+    "composer": {
+      "prompt": "この曲の作曲者は？",
+      "correct": "正解！作曲者: {composer}",
+      "incorrect": "正解は {composer} でした"
+    }
   }
 }

--- a/web/mocks/fixtures/rounds.composer.start.json
+++ b/web/mocks/fixtures/rounds.composer.start.json
@@ -1,0 +1,50 @@
+{
+  "round": {
+    "token": "tok_0001",
+    "progress": {
+      "index": 1,
+      "total": 10
+    }
+  },
+  "question": {
+    "id": "q_0001",
+    "prompt": "このBGMの作曲者は？",
+    "choices": [
+      {
+        "id": "a",
+        "label": "作曲者A"
+      },
+      {
+        "id": "b",
+        "label": "作曲者B"
+      },
+      {
+        "id": "c",
+        "label": "作曲者C"
+      },
+      {
+        "id": "d",
+        "label": "作曲者D"
+      }
+    ],
+    "reveal": {
+      "links": [
+        {
+          "provider": "youtube",
+          "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        },
+        {
+          "provider": "appleMusic",
+          "url": "https://music.apple.com/jp/album/xyz/123"
+        }
+      ]
+    },
+    "artwork": {
+      "url": "https://example.com/art.jpg",
+      "width": 1024,
+      "height": 1024,
+      "alt": "Album Art"
+    }
+  },
+  "finished": false
+}

--- a/web/mocks/fixtures/rounds.composer.start.json
+++ b/web/mocks/fixtures/rounds.composer.start.json
@@ -44,7 +44,9 @@
       "width": 1024,
       "height": 1024,
       "alt": "Album Art"
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds.start.ok.json
+++ b/web/mocks/fixtures/rounds.start.ok.json
@@ -44,7 +44,9 @@
       "width": 1024,
       "height": 1024,
       "alt": "Album Art"
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds.start.ok.json
+++ b/web/mocks/fixtures/rounds.start.ok.json
@@ -8,7 +8,7 @@
   },
   "question": {
     "id": "q_0001",
-    "prompt": "このBGMの作曲者は？",
+    "prompt": "この曲のゲームタイトルは?",
     "choices": [
       {
         "id": "a",
@@ -44,9 +44,7 @@
       "width": 1024,
       "height": 1024,
       "alt": "Album Art"
-    },
-    "mode": "vgm_composer-ja",
-    "arm": "treatment"
+    }
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/difficulty-easy.json
+++ b/web/mocks/fixtures/rounds/difficulty-easy.json
@@ -45,7 +45,9 @@
           "url": "https://www.youtube.com/watch?v=easy123"
         }
       ]
-    }
+    },
+    "mode": "vgm_v1-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/difficulty-hard.json
+++ b/web/mocks/fixtures/rounds/difficulty-hard.json
@@ -45,7 +45,9 @@
           "url": "https://www.youtube.com/watch?v=hard123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/era-90s.json
+++ b/web/mocks/fixtures/rounds/era-90s.json
@@ -45,7 +45,9 @@
           "url": "https://www.youtube.com/watch?v=90s123"
         }
       ]
-    }
+    },
+    "mode": "vgm_v1-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/index.ts
+++ b/web/mocks/fixtures/rounds/index.ts
@@ -1,5 +1,6 @@
 // Auto-generated: cleaned fixtures
 import startRound from '../rounds.start.ok.json';
+import composerStartRound from '../rounds.composer.start.json';
 import next01 from './next.01.json';
 import next02 from './next.02.json';
 import next03 from './next.03.json';
@@ -72,4 +73,17 @@ export function getFirstQuestionByFilters(
 
   // Default: return first question from default fixture
   return getQuestionByIndex(1);
+}
+
+export function getFirstQuestionByMode(
+  modeId: string | undefined,
+  difficulty?: Difficulty,
+  era?: Era,
+  series?: string[],
+): Question | undefined {
+  if (modeId === 'vgm_composer-ja') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return composerStartRound.question as any as Question;
+  }
+  return getFirstQuestionByFilters(difficulty, era, series);
 }

--- a/web/mocks/fixtures/rounds/next.01.json
+++ b/web/mocks/fixtures/rounds/next.01.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.02.json
+++ b/web/mocks/fixtures/rounds/next.02.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.03.json
+++ b/web/mocks/fixtures/rounds/next.03.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.04.json
+++ b/web/mocks/fixtures/rounds/next.04.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.05.json
+++ b/web/mocks/fixtures/rounds/next.05.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.06.json
+++ b/web/mocks/fixtures/rounds/next.06.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.07.json
+++ b/web/mocks/fixtures/rounds/next.07.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.08.json
+++ b/web/mocks/fixtures/rounds/next.08.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/mocks/fixtures/rounds/next.09.json
+++ b/web/mocks/fixtures/rounds/next.09.json
@@ -44,7 +44,9 @@
           "url": "https://music.apple.com/jp/album/xyz/123"
         }
       ]
-    }
+    },
+    "mode": "vgm_composer-ja",
+    "arm": "treatment"
   },
   "finished": false
 }

--- a/web/src/components/QuestionCard.tsx
+++ b/web/src/components/QuestionCard.tsx
@@ -9,6 +9,7 @@ import type { Choice } from '@/src/features/quiz/api/types';
 export type QuestionCardProps = {
   questionId?: string;
   prompt: string;
+  mode?: string;
   choices: Choice[];
   selectedId?: string;
   disabled?: boolean;
@@ -19,6 +20,7 @@ export type QuestionCardProps = {
 export default function QuestionCard({
   questionId,
   prompt,
+  mode,
   choices,
   selectedId,
   disabled,
@@ -26,6 +28,7 @@ export default function QuestionCard({
   onSubmit
 }: QuestionCardProps) {
   const { t } = useI18n();
+  const promptText = mode === 'vgm_composer-ja' ? t('quiz.composer.prompt') : prompt;
 
   return (
     <div className="w-full max-w-2xl mx-auto">
@@ -36,7 +39,7 @@ export default function QuestionCard({
           data-question-id={questionId}
           id="question-prompt"
         >
-          {prompt}
+          {promptText}
         </h2>
         <div role="radiogroup" aria-labelledby="question-prompt" className="space-y-2">
           {choices.map((c, idx) => {

--- a/web/src/components/RevealCard.tsx
+++ b/web/src/components/RevealCard.tsx
@@ -54,12 +54,22 @@ export default function RevealCard({ reveal, result, telemetry }: { reveal?: Rev
   const [inline] = React.useState<boolean>(getInlinePlayback());
   const primary = pickPrimaryLink(reveal);
 
+  const isComposerMode = reveal?.questionId?.startsWith('composer') || reveal?.meta?.composer;
+
   const embedUrl = primary?.provider === 'youtube' ? toYouTubeEmbed(primary.url) : null;
 
   const meta = reveal?.meta;
   const outcome = result ? getOutcomeDisplay(result.outcome) : undefined;
   const [fallbackLogged, setFallbackLogged] = React.useState(false);
   const [errorLogged, setErrorLogged] = React.useState(false);
+  const composerLine = React.useMemo(() => {
+    if (!isComposerMode || !meta?.composer) return null;
+    if (!result) return t('quiz.composer.prompt');
+    const isCorrect = result.outcome === 'correct';
+    return isCorrect
+      ? t('quiz.composer.correct', { composer: meta.composer })
+      : t('quiz.composer.incorrect', { composer: meta.composer });
+  }, [isComposerMode, meta?.composer, result, t]);
 
   React.useEffect(() => {
     setFallbackLogged(false);
@@ -149,7 +159,12 @@ export default function RevealCard({ reveal, result, telemetry }: { reveal?: Rev
         <div className="mb-3 text-sm text-card-foreground">
           {meta.workTitle ? <div><span className="font-medium">{t('reveal.work')}:</span> {meta.workTitle}</div> : null}
           {meta.trackTitle ? <div><span className="font-medium">{t('reveal.track')}:</span> {meta.trackTitle}</div> : null}
-          {meta.composer ? <div><span className="font-medium">{t('reveal.composer')}:</span> {meta.composer}</div> : null}
+          {meta.composer ? (
+            <div>
+              <span className="font-medium">{t('reveal.composer')}:</span> {meta.composer}
+            </div>
+          ) : null}
+          {composerLine ? <div className="text-muted-foreground">{composerLine}</div> : null}
         </div>
       ) : null}
       {primary ? (

--- a/web/src/components/RevealCard.tsx
+++ b/web/src/components/RevealCard.tsx
@@ -49,14 +49,20 @@ type RevealTelemetry = {
   questionId?: string;
 };
 
-export default function RevealCard({ reveal, result, telemetry }: { reveal?: Reveal; result?: ResultInfo; telemetry?: RevealTelemetry }) {
+export default function RevealCard({
+  reveal,
+  result,
+  telemetry,
+  isComposerMode = false,
+}: {
+  reveal?: Reveal;
+  result?: ResultInfo;
+  telemetry?: RevealTelemetry;
+  isComposerMode?: boolean;
+}) {
   const { t } = useI18n();
   const [inline] = React.useState<boolean>(getInlinePlayback());
   const primary = pickPrimaryLink(reveal);
-
-  const isComposerMode = Boolean(
-    reveal?.questionId?.startsWith('composer') || reveal?.meta?.composer,
-  );
 
   const embedUrl = primary?.provider === 'youtube' ? toYouTubeEmbed(primary.url) : null;
 

--- a/web/src/components/RevealCard.tsx
+++ b/web/src/components/RevealCard.tsx
@@ -54,7 +54,9 @@ export default function RevealCard({ reveal, result, telemetry }: { reveal?: Rev
   const [inline] = React.useState<boolean>(getInlinePlayback());
   const primary = pickPrimaryLink(reveal);
 
-  const isComposerMode = reveal?.questionId?.startsWith('composer') || reveal?.meta?.composer;
+  const isComposerMode = Boolean(
+    reveal?.questionId?.startsWith('composer') || reveal?.meta?.composer,
+  );
 
   const embedUrl = primary?.provider === 'youtube' ? toYouTubeEmbed(primary.url) : null;
 

--- a/web/src/features/quiz/api/manifest.ts
+++ b/web/src/features/quiz/api/manifest.ts
@@ -53,6 +53,7 @@ const DEFAULT_MANIFEST: Manifest = {
   features: {
     inlinePlaybackDefault: false,
     imageProxyEnabled: false,
+    composerModeEnabled: false,
   },
 }
 

--- a/web/src/features/quiz/api/schemas.ts
+++ b/web/src/features/quiz/api/schemas.ts
@@ -27,6 +27,7 @@ export const FacetsSchema = z.object({
 export const FeaturesSchema = z.object({
   inlinePlaybackDefault: z.boolean(),
   imageProxyEnabled: z.boolean(),
+  composerModeEnabled: z.boolean(),
 })
 
 export const ManifestSchema = z.object({
@@ -54,6 +55,8 @@ const Phase1ChoiceSchema: z.ZodType<Phase1Choice> = z.object({
 const Phase1QuestionSchema: z.ZodType<Phase1Question> = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
+  mode: z.string().min(1).optional(),
+  arm: z.string().min(1).optional(),
 })
 
 const Phase1RevealSchema: z.ZodType<Phase1Reveal> = z.object({
@@ -82,6 +85,7 @@ export const Phase1StartResponseSchema: z.ZodType<Phase1StartResponse> = z.objec
       filters: z.record(z.string(), z.unknown()).optional(),
       progress: RoundProgressSchema,
       token: z.string().min(1),
+      arm: z.string().min(1).optional(),
     })
     .optional(),
 })
@@ -97,6 +101,11 @@ export const Phase1NextResponseSchema: z.ZodType<Phase1NextResponse> = z.object(
   continuationToken: z.string().optional(),
   progress: RoundProgressSchema.optional(),
   finished: z.boolean(),
+  round: z
+    .object({
+      arm: z.string().min(1).optional(),
+    })
+    .optional(),
 })
 
 export function ensureApiResponse<T>(payload: unknown, schema: z.ZodType<T>): T {

--- a/web/src/features/quiz/api/types.ts
+++ b/web/src/features/quiz/api/types.ts
@@ -106,6 +106,7 @@ export interface Phase1StartResponse {
   round?: {
     id: string;
     mode: string;
+    arm?: string;
     date: string;
     filters?: Record<string, unknown>;
     progress: {

--- a/web/src/features/quiz/api/types.ts
+++ b/web/src/features/quiz/api/types.ts
@@ -34,6 +34,8 @@ export interface Artwork {
 export interface Question {
   id: ID;
   prompt: string;
+  mode?: string;
+  arm?: string;
   choices: Choice[];
   reveal?: Reveal;
   artwork?: Artwork;
@@ -44,6 +46,8 @@ export interface Progress { index: number; total: number; }
 export interface RoundMeta {
   token: string;
   progress: Progress;
+  mode?: string;
+  arm?: string;
 }
 
 export interface RoundsStartResponse {
@@ -69,6 +73,8 @@ export interface RoundsNextResponse {
 export interface Phase1Question {
   id: string;
   title: string;
+  mode?: string;
+  arm?: string;
 }
 
 export interface Phase1Choice {

--- a/web/src/features/quiz/lib/reveal.ts
+++ b/web/src/features/quiz/lib/reveal.ts
@@ -33,6 +33,8 @@ export function toQuestionRecord(params: {
   return {
     questionId: question.id,
     prompt: question.prompt,
+    mode: question.mode,
+    arm: question.arm,
     choiceId,
     choiceLabel,
     correctChoiceId,

--- a/web/src/features/quiz/playReducer.ts
+++ b/web/src/features/quiz/playReducer.ts
@@ -9,6 +9,7 @@ export const SKIP_CHOICE_ID = '__skip__';
 
 export type PlayState = {
   token?: string;
+  roundId?: string;
   question?: Question;
   progress?: ProgressInfo;
   loading: boolean;
@@ -32,6 +33,7 @@ export type PlayAction =
       type: 'STARTED';
       payload: {
         token: string;
+        roundId?: string;
         question?: Question;
         progress?: ProgressInfo;
         beganAt: number;
@@ -66,9 +68,10 @@ export function playReducer(state: PlayState, action: PlayAction): PlayState {
       return { ...state, loading: true, error: undefined, started: true };
 
     case 'STARTED': {
-      const { token, question, progress, beganAt, startedAt, currentReveal } = action.payload;
+      const { token, roundId, question, progress, beganAt, startedAt, currentReveal } = action.payload;
       return {
         token,
+        roundId,
         question,
         progress,
         loading: false,
@@ -128,6 +131,10 @@ export function playReducer(state: PlayState, action: PlayAction): PlayState {
         ? (qn as Phase1NextResponse).continuationToken ?? state.token
         : (qn as RoundsNextResponse).round?.token ?? state.token;
 
+      const nextRoundId = isPhase1
+        ? state.roundId
+        : (qn as RoundsNextResponse).round?.id ?? state.roundId;
+
       // Phase 1: question has been converted to Question format by useAnswerProcessor
       // Safe to use qn.question directly
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,6 +145,7 @@ export function playReducer(state: PlayState, action: PlayAction): PlayState {
         loading: false,
         error: undefined,
         token: nextToken,
+        roundId: nextRoundId,
         question: nextQuestion!,
         progress: nextProgress,
         selectedId: undefined,

--- a/web/src/features/quiz/playReducer.ts
+++ b/web/src/features/quiz/playReducer.ts
@@ -131,9 +131,7 @@ export function playReducer(state: PlayState, action: PlayAction): PlayState {
         ? (qn as Phase1NextResponse).continuationToken ?? state.token
         : (qn as RoundsNextResponse).round?.token ?? state.token;
 
-      const nextRoundId = isPhase1
-        ? state.roundId
-        : (qn as RoundsNextResponse).round?.id ?? state.roundId;
+      const nextRoundId = state.roundId;
 
       // Phase 1: question has been converted to Question format by useAnswerProcessor
       // Safe to use qn.question directly

--- a/web/src/features/quiz/useAnswerProcessor.ts
+++ b/web/src/features/quiz/useAnswerProcessor.ts
@@ -231,6 +231,6 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
         onError?.(apiError, retry);
       }
     },
-    [phase, continuationToken, question, remainingMs, dispatch, beganAt, currentReveal, history, tally, progress?.total, progress?.index, startedAt, onError, getActiveFilters]
+    [phase, continuationToken, roundId, question, remainingMs, dispatch, beganAt, currentReveal, history, tally, progress?.total, progress?.index, startedAt, onError, getActiveFilters]
   );
 }

--- a/web/src/features/quiz/useAnswerProcessor.ts
+++ b/web/src/features/quiz/useAnswerProcessor.ts
@@ -21,6 +21,7 @@ type AnswerMode = { kind: 'answer' | 'timeout' | 'skip'; choiceId?: string };
 type ProcessAnswerParams = {
   phase: 'question' | 'reveal';
   continuationToken?: string; // Phase 1: token → continuationToken
+  roundId?: string;
   question?: Question;
   remainingMs: number;
   beganAt?: number;
@@ -42,6 +43,7 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
   const {
     phase,
     continuationToken,
+    roundId,
     question,
     remainingMs,
     beganAt,
@@ -144,7 +146,7 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
         const inlineEnabled = getInlinePlayback();
 
         recordMetricsEvent('answer_result', {
-          roundId: continuationToken,
+          roundId: roundId || continuationToken,
           questionIdx: progress?.index,
           attrs: {
             questionId: question.id,
@@ -180,7 +182,7 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
           );
 
           recordMetricsEvent('quiz_complete', {
-            roundId: continuationToken,
+            roundId: roundId || continuationToken,
             attrs: {
               mode: question.mode,
               arm: question.arm,

--- a/web/src/features/quiz/useAnswerProcessor.ts
+++ b/web/src/features/quiz/useAnswerProcessor.ts
@@ -148,6 +148,8 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
           questionIdx: progress?.index,
           attrs: {
             questionId: question.id,
+            mode: question.mode,
+            arm: question.arm,
             outcome,
             points,
             remainingSeconds: Math.floor(remainingForCalc / 1000),
@@ -178,6 +180,8 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
           recordMetricsEvent('quiz_complete', {
             roundId: continuationToken,
             attrs: {
+              mode: question.mode,
+              arm: question.arm,
               total: totalQuestions,
               points: updatedTally.points,
               correct: updatedTally.correct,
@@ -193,13 +197,15 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
         const convertedRes = res.question
           ? {
               ...res,
-              question: {
-                id: res.question.id,
-                prompt: res.question.title,
-                choices: (res.choices ?? []).map(c => ({
-                  id: c.id,
-                  label: c.text,
-                })),
+            question: {
+              id: res.question.id,
+              prompt: res.question.title,
+              mode: res.question.mode,
+              arm: res.question.arm,
+              choices: (res.choices ?? []).map(c => ({
+                id: c.id,
+                label: c.text,
+              })),
                 // MSW fixtures have these fields; real Phase1 API won't, but we'll handle that in Phase2
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 reveal: (res.question as any).reveal,

--- a/web/src/features/quiz/useAnswerProcessor.ts
+++ b/web/src/features/quiz/useAnswerProcessor.ts
@@ -174,6 +174,8 @@ export function useAnswerProcessor(params: ProcessAnswerParams) {
               total: totalQuestions,
               startedAt,
               finishedAt,
+              mode: question.mode,
+              arm: question.arm,
             })
           );
 

--- a/web/src/lib/filter-context.tsx
+++ b/web/src/lib/filter-context.tsx
@@ -7,12 +7,14 @@ export interface FilterState {
   difficulty?: Difficulty
   era?: Era
   series: string[]
+  mode?: string
 }
 
 const defaultFilters: FilterState = {
   difficulty: 'mixed',
   era: 'mixed',
   series: [],
+  mode: undefined,
 }
 
 const FilterContext = createContext<{
@@ -20,6 +22,7 @@ const FilterContext = createContext<{
   setDifficulty: (difficulty?: Difficulty) => void
   setEra: (era?: Era) => void
   setSeries: (series: string[]) => void
+  setMode: (mode?: string) => void
   reset: () => void
   isDefault: () => boolean
 }>({
@@ -27,6 +30,7 @@ const FilterContext = createContext<{
   setDifficulty: () => {},
   setEra: () => {},
   setSeries: () => {},
+  setMode: () => {},
   reset: () => {},
   isDefault: () => true,
 })
@@ -55,6 +59,13 @@ export function FilterProvider({ children }: { children: ReactNode }) {
     }))
   }
 
+  const setMode = (mode?: string) => {
+    setFilters((prev) => ({
+      ...prev,
+      mode: mode || undefined,
+    }))
+  }
+
   const reset = () => {
     setFilters(defaultFilters)
   }
@@ -63,7 +74,8 @@ export function FilterProvider({ children }: { children: ReactNode }) {
     return (
       (filters.difficulty === 'mixed' || filters.difficulty === undefined) &&
       (filters.era === 'mixed' || filters.era === undefined) &&
-      filters.series.length === 0
+      filters.series.length === 0 &&
+      !filters.mode
     )
   }
 
@@ -74,6 +86,7 @@ export function FilterProvider({ children }: { children: ReactNode }) {
         setDifficulty,
         setEra,
         setSeries,
+        setMode,
         reset,
         isDefault,
       }}

--- a/web/src/lib/metrics/types.ts
+++ b/web/src/lib/metrics/types.ts
@@ -3,6 +3,8 @@ export const METRICS_EVENT_NAMES = [
   'answer_result',
   'quiz_start',
   'quiz_complete',
+  'quiz_resume',
+  'quiz_revisit',
   'reveal_open_external',
   'embed_error',
   'embed_fallback_to_link',

--- a/web/src/lib/metrics/types.ts
+++ b/web/src/lib/metrics/types.ts
@@ -1,6 +1,7 @@
 export const METRICS_EVENT_NAMES = [
   'answer_select',
   'answer_result',
+  'quiz_start',
   'quiz_complete',
   'reveal_open_external',
   'embed_error',

--- a/web/src/lib/resultStorage.ts
+++ b/web/src/lib/resultStorage.ts
@@ -49,6 +49,8 @@ function normalizeSummary(summary: Partial<ResultSummary> | undefined): ResultSu
     total: summary.total ?? 0,
     score: summary.score ?? { ...EMPTY_SCORE },
     questions: Array.isArray(summary.questions) ? summary.questions : [],
+    mode: summary.mode,
+    arm: summary.arm,
     startedAt: summary.startedAt,
     finishedAt: summary.finishedAt,
     durationMs: summary.durationMs,

--- a/web/src/lib/resultStorage.ts
+++ b/web/src/lib/resultStorage.ts
@@ -27,6 +27,8 @@ export type ResultSummary = {
   total: number;
   score: ScoreBreakdown;
   questions: QuestionRecord[];
+  mode?: string;
+  arm?: string;
   startedAt?: string;  // ISO8601
   finishedAt?: string; // ISO8601
   durationMs?: number; // derived

--- a/web/src/lib/resultStorage.ts
+++ b/web/src/lib/resultStorage.ts
@@ -3,6 +3,8 @@ export type Outcome = 'correct' | 'wrong' | 'timeout' | 'skip';
 export type QuestionRecord = {
   questionId: string;
   prompt: string;
+  mode?: string;
+  arm?: string;
   choiceId?: string;
   choiceLabel?: string;
   correctChoiceId?: string;

--- a/web/src/lib/scoring.ts
+++ b/web/src/lib/scoring.ts
@@ -43,6 +43,8 @@ export function composeSummary(input: {
   total: number;
   startedAt?: string;
   finishedAt: string;
+  mode?: string;
+  arm?: string;
 }): ResultSummary {
   return {
     answeredCount: input.history.length,
@@ -51,5 +53,7 @@ export function composeSummary(input: {
     questions: input.history,
     startedAt: input.startedAt,
     finishedAt: input.finishedAt,
+    mode: input.mode,
+    arm: input.arm,
   };
 }

--- a/web/src/lib/token-shared.ts
+++ b/web/src/lib/token-shared.ts
@@ -18,6 +18,7 @@ export interface Phase2TokenPayload {
   iat: number // Issued at (Unix timestamp)
   exp: number // Expiration (Unix timestamp)
   mode?: string // Quiz mode identifier
+  arm?: string // Experiment arm identifier (treatment/control)
   date?: string // Round date (YYYY-MM-DD)
   aud?: string // Audience (optional, e.g., "rounds")
   nbf?: number // Not before (optional)

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -229,7 +229,7 @@ test.describe('Play page features', () => {
     await expect(externalLink).toHaveAttribute('target', '_blank');
     await expect(externalLink).toHaveAttribute('rel', /noopener/);
     await expect(page.getByText('Work:')).toBeVisible();
-    await expect(page.getByText('Composer:')).toBeVisible();
+    await expect(page.locator('dt', { hasText: 'Composer:' })).toBeVisible();
   });
 
   test('result summary reflects mixed outcomes', async ({ page }) => {

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -608,7 +608,11 @@ test.describe('Play page features', () => {
     });
 
     expect(result.attempts).toBeGreaterThanOrEqual(2);
+    const start = result.events.find((event) => event.name === 'quiz_start');
     const answer = result.events.find((event) => event.name === 'answer_result');
+    expect(start).toBeTruthy();
+    expect(typeof start?.attrs?.mode).toBe('string');
+    expect(['treatment', 'control']).toContain(String(start?.attrs?.arm ?? ''));
     expect(answer).toBeTruthy();
     expect(typeof answer?.attrs?.mode).toBe('string');
     expect(['treatment', 'control']).toContain(String(answer?.attrs?.arm ?? '')); 

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -608,7 +608,12 @@ test.describe('Play page features', () => {
     });
 
     expect(result.attempts).toBeGreaterThanOrEqual(2);
-    expect(result.events.some((event) => event.name === 'answer_result')).toBe(true);
+    const answer = result.events.find((event) => event.name === 'answer_result');
+    expect(answer).toBeTruthy();
+    expect(typeof answer?.attrs?.mode).toBe('string');
+    expect(['treatment', 'control']).toContain(String(answer?.attrs?.arm ?? '')); 
+    expect(typeof answer?.attrs?.remainingSeconds).toBe('number');
+    expect(typeof answer?.attrs?.elapsedMs).toBe('number');
   });
 
   test('resends metrics after network failures', async ({ page }) => {
@@ -719,7 +724,12 @@ test.describe('Play page features', () => {
     });
 
     expect(result.attempts).toBeGreaterThanOrEqual(3);
-    expect(result.events.some((event) => event.name === 'answer_result')).toBe(true);
+    const answer = result.events.find((event) => event.name === 'answer_result');
+    expect(answer).toBeTruthy();
+    expect(typeof answer?.attrs?.mode).toBe('string');
+    expect(['treatment', 'control']).toContain(String(answer?.attrs?.arm ?? ''));
+    expect(typeof answer?.attrs?.remainingSeconds).toBe('number');
+    expect(typeof answer?.attrs?.elapsedMs).toBe('number');
   });
 });
 

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -163,7 +163,7 @@ async function enableStartErrorInterceptor(page: Page) {
 test.describe('Play page features', () => {
 
   test('composer mode selection sends mode param and shows composer prompt', async ({ page }) => {
-    await page.goto('/play');
+    await page.goto('/play?autostart=0');
 
     // Select composer mode (manifest enables it in MSW)
     const modeRadio = page.getByTestId('mode-vgm_composer-ja');
@@ -205,7 +205,7 @@ test.describe('Play page features', () => {
   });
 
   test('reveal view exposes external link metadata', async ({ page }) => {
-    await page.goto('/play');
+    await page.goto('/play?autostart=0');
 
     await waitForQuestion(page, 0);
 
@@ -228,7 +228,7 @@ test.describe('Play page features', () => {
   });
 
   test('result summary reflects mixed outcomes', async ({ page }) => {
-    await page.goto('/play');
+    await page.goto('/play?autostart=0');
 
     for (const [index, questionId] of QUESTION_IDS.entries()) {
       await waitForQuestion(page, index);

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -336,7 +336,7 @@ test.describe('Play page features', () => {
     await expect(timeoutCard.getByText('Timeout')).toBeVisible();
     // After Phase 4 a11y improvements, answer is in <dl> structure
     const answerDl = timeoutCard.locator('dl').filter({ hasText: 'Your answer:' });
-    await expect(answerDl.getByText('Your answer:')).toBeVisible();
+    await expect(answerDl.locator('dt', { hasText: 'Your answer:' })).toBeVisible();
     await expect(answerDl.locator('dd', { hasText: '—' })).toBeVisible();
 
     await page.evaluate(() => {

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -165,13 +165,10 @@ test.describe('Play page features', () => {
   test('composer mode selection sends mode param and shows composer prompt', async ({ page }) => {
     await page.goto('/play');
 
-    // Select composer mode if mode selector is present
+    // Select composer mode (manifest enables it in MSW)
     const modeRadio = page.getByTestId('mode-vgm_composer-ja');
-    const hasModeSelector = await modeRadio.isVisible({ timeout: 1000 }).catch(() => false);
-
-    if (hasModeSelector) {
-      await modeRadio.check();
-    }
+    await expect(modeRadio).toBeVisible({ timeout: 5_000 });
+    await modeRadio.check();
 
     const request = await waitForStartRequest(page, async () => {
       const started = await ensureFilterVisibleAndStart(page);
@@ -184,9 +181,7 @@ test.describe('Play page features', () => {
     });
 
     const payload = parseStartRequest(request);
-    if (hasModeSelector) {
-      expect(payload.mode).toBe('vgm_composer-ja');
-    }
+    expect(payload.mode).toBe('vgm_composer-ja');
 
     await page.getByTestId('question-prompt').waitFor({ timeout: 60_000 });
     const promptText = await page.getByTestId('question-prompt').innerText();

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -229,7 +229,7 @@ test.describe('Play page features', () => {
     await expect(externalLink).toHaveAttribute('target', '_blank');
     await expect(externalLink).toHaveAttribute('rel', /noopener/);
     await expect(page.getByText('Work:')).toBeVisible();
-    await expect(page.locator('dt', { hasText: 'Composer:' })).toBeVisible();
+    await expect(page.locator('span.font-medium', { hasText: 'Composer:' })).toBeVisible();
   });
 
   test('result summary reflects mixed outcomes', async ({ page }) => {

--- a/web/tests/e2e/play-features.spec.ts
+++ b/web/tests/e2e/play-features.spec.ts
@@ -251,7 +251,7 @@ test.describe('Play page features', () => {
     await expect(page.getByText('✓ 9', { exact: true })).toBeVisible();
     await expect(page.getByText(/Answered: 10/)).toBeVisible();
 
-    const firstCard = page.locator('li', { hasText: '#1 — このBGMの作曲者は？' }).first();
+    const firstCard = page.locator('li', { hasText: '#1 — この曲のゲームタイトルは?' }).first();
     await expect(firstCard).toBeVisible();
     await expect(firstCard.getByText('Wrong')).toBeVisible();
   });
@@ -327,7 +327,7 @@ test.describe('Play page features', () => {
     await page.waitForURL('**/result');
     await expect(page.getByText('? 1', { exact: true })).toBeVisible();
 
-    const timeoutCard = page.locator('li', { hasText: '#1 — このBGMの作曲者は？' }).first();
+    const timeoutCard = page.locator('li', { hasText: '#1 — この曲のゲームタイトルは?' }).first();
     await expect(timeoutCard.getByText('Timeout')).toBeVisible();
     // After Phase 4 a11y improvements, answer is in <dl> structure
     const answerDl = timeoutCard.locator('dl').filter({ hasText: 'Your answer:' });

--- a/web/tests/unit/apiSchemas.spec.ts
+++ b/web/tests/unit/apiSchemas.spec.ts
@@ -35,6 +35,7 @@ const baseManifest = {
   features: {
     inlinePlaybackDefault: false,
     imageProxyEnabled: false,
+    composerModeEnabled: false,
   },
 }
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -32,7 +32,7 @@ export default {
 
       // GET /v1/manifest
       if (url.pathname === '/v1/manifest' && request.method === 'GET') {
-        return handleManifestRequest()
+        return handleManifestRequest(env)
       }
 
       // POST /v1/rounds/start

--- a/workers/api/src/routes/availability.ts
+++ b/workers/api/src/routes/availability.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types'
-import type { Env } from '../../../shared/types/env'
 import { getManifest } from '../../../shared/data/manifest'
+import type { Env } from '../../../shared/types/env'
 
 interface FilterOptions {
   difficulty?: string[]

--- a/workers/api/src/routes/manifest.ts
+++ b/workers/api/src/routes/manifest.ts
@@ -1,11 +1,14 @@
-import { manifest } from '../../../shared/data/manifest'
+import type { Env } from '../../../shared/types/env'
+import { getManifest } from '../../../shared/data/manifest'
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
 }
 
-export function handleManifestRequest(): Response {
+export function handleManifestRequest(env: Env): Response {
+  const manifest = getManifest(env)
+
   return new Response(JSON.stringify(manifest), {
     status: 200,
     headers: JSON_HEADERS,

--- a/workers/api/src/routes/manifest.ts
+++ b/workers/api/src/routes/manifest.ts
@@ -1,5 +1,5 @@
-import type { Env } from '../../../shared/types/env'
 import { getManifest } from '../../../shared/data/manifest'
+import type { Env } from '../../../shared/types/env'
 
 const JSON_HEADERS = {
   'Content-Type': 'application/json',

--- a/workers/api/src/routes/metrics.ts
+++ b/workers/api/src/routes/metrics.ts
@@ -4,7 +4,10 @@ import type { Env } from '../../../shared/types/env'
 const ALLOWED_EVENT_NAMES = new Set([
   'answer_select',
   'answer_result',
+  'quiz_start',
   'quiz_complete',
+  'quiz_resume',
+  'quiz_revisit',
   'reveal_open_external',
   'embed_error',
   'embed_fallback_to_link',

--- a/workers/api/src/routes/rounds.ts
+++ b/workers/api/src/routes/rounds.ts
@@ -245,7 +245,8 @@ export async function handleRoundsStart(request: Request, env: Env): Promise<Res
       : generateUUID().replace(/-/g, '').substring(0, 16)
   const filtersHash = hashFilterKey(filterKey)
   const treatmentRatio = resolveTreatmentRatio(env)
-  const arm = assignArm(filtersHash, treatmentRatio)
+  const assignmentHash = hashFilterKey(`${filterKey}:${roundId}`)
+  const arm = assignArm(assignmentHash, treatmentRatio)
 
   const token = await createJWSToken(
     {

--- a/workers/api/src/routes/rounds.ts
+++ b/workers/api/src/routes/rounds.ts
@@ -256,7 +256,8 @@ export async function handleRoundsStart(request: Request, env: Env): Promise<Res
       : generateUUID().replace(/-/g, '').substring(0, 16)
   const filtersHash = hashFilterKey(filterKey)
   const treatmentRatio = resolveTreatmentRatio(env)
-  const assignmentHash = hashFilterKey(`${filtersHash}:${seed}`)
+  // Arm assignment must not be client-controllable; use server-generated roundId as entropy
+  const assignmentHash = hashFilterKey(`${filtersHash}:${roundId}`)
   const arm = assignArm(assignmentHash, treatmentRatio)
 
   const token = await createJWSToken(

--- a/workers/pipeline/src/index.ts
+++ b/workers/pipeline/src/index.ts
@@ -10,6 +10,12 @@ import { handleDiscovery } from './stages/discovery'
 import { handleIntake } from './stages/intake'
 import { handlePublish } from './stages/publish'
 
+function toBooleanFlag(value?: string): boolean {
+  if (!value) return false
+  const v = value.toLowerCase()
+  return v === '1' || v === 'true' || v === 'on' || v === 'yes'
+}
+
 export default {
   /**
    * Scheduled event handler (Cron Triggers)
@@ -116,7 +122,7 @@ export default {
     }
 
     // Optional: generate composer mode export when enabled
-    if (env.COMPOSER_MODE_ENABLED) {
+    if (toBooleanFlag(env.COMPOSER_MODE_ENABLED)) {
       logEvent(env, 'info', {
         event: 'cron.publish.composer',
         status: 'start',

--- a/workers/pipeline/src/stages/publish.ts
+++ b/workers/pipeline/src/stages/publish.ts
@@ -13,7 +13,11 @@ import {
   normalizeFilters,
 } from '../../../shared/lib/filters'
 import { sha256 } from '../../../shared/lib/hash'
-import { isObservabilityEnabled, logEvent, sendSlackNotification } from '../../../shared/lib/observability'
+import {
+  isObservabilityEnabled,
+  logEvent,
+  sendSlackNotification,
+} from '../../../shared/lib/observability'
 import type { Env } from '../../../shared/types/env'
 import type { Choice, DailyExport, Question, QuestionFacets } from '../../../shared/types/export'
 import type { FilterOptions } from '../../../shared/types/filters'
@@ -506,7 +510,9 @@ async function getAllGameTitles(db: D1Database): Promise<string[]> {
 
 async function getAllComposers(db: D1Database): Promise<string[]> {
   const result = await db
-    .prepare('SELECT DISTINCT composer FROM tracks_normalized WHERE composer IS NOT NULL AND composer != ""')
+    .prepare(
+      'SELECT DISTINCT composer FROM tracks_normalized WHERE composer IS NOT NULL AND composer != ""',
+    )
     .all<{ composer: string }>()
 
   return (result.results || []).map((r) => r.composer)
@@ -536,10 +542,7 @@ function generateComposerChoices(
     { text: selectedWrong[2], correct: false },
   ]
 
-  const shuffledChoices = shuffleArrayComposer(
-    choicesWithoutIds,
-    `${questionId}-composer-shuffle`,
-  )
+  const shuffledChoices = shuffleArrayComposer(choicesWithoutIds, `${questionId}-composer-shuffle`)
   const choiceIds = ['a', 'b', 'c', 'd'] as const
 
   return shuffledChoices.map((choice, index) => ({
@@ -610,7 +613,10 @@ async function getComposerCoverage(
     WHERE ${whereClause}
   `
 
-  const result = await db.prepare(query).bind(...bindings).first<{ total: number; withComposer: number }>()
+  const result = await db
+    .prepare(query)
+    .bind(...bindings)
+    .first<{ total: number; withComposer: number }>()
   const available = result?.total ?? 0
   const withComposer = result?.withComposer ?? 0
   const missing = Math.max(available - withComposer, 0)

--- a/workers/pipeline/src/stages/publish.ts
+++ b/workers/pipeline/src/stages/publish.ts
@@ -44,7 +44,6 @@ interface TrackRow {
   genres: string | null
   series_tags: string | null
   era: string | null
-  composer: string | null
 }
 
 const COVERAGE_ALERT_THRESHOLD = 0.05

--- a/workers/shared/data/manifest.ts
+++ b/workers/shared/data/manifest.ts
@@ -1,30 +1,72 @@
+import type { Env } from '../types/env'
 import type { Manifest } from '../types/manifest'
 
-export const manifest: Manifest = {
-  schema_version: 2,
-  modes: [
-    {
-      id: 'vgm_v1-ja',
-      title: 'VGM Quiz Vol.1 (JA)',
-      defaultTotal: 10,
-      locale: 'ja',
-    },
-  ],
-  facets: {
-    difficulty: ['easy', 'normal', 'hard', 'mixed'],
-    era: ['80s', '90s', '00s', '10s', '20s', 'mixed'],
-    series: ['ff', 'dq', 'zelda', 'mario', 'sonic', 'pokemon', 'mixed'],
-  },
-  features: {
-    inlinePlaybackDefault: false,
-    imageProxyEnabled: false,
-  },
+const BASE_MODE: Manifest['modes'][number] = {
+  id: 'vgm_v1-ja',
+  title: 'VGM Quiz Vol.1 (JA)',
+  defaultTotal: 10,
+  locale: 'ja',
 }
 
-export function getDefaultMode(): Manifest['modes'][number] {
+const COMPOSER_MODE: Manifest['modes'][number] = {
+  id: 'vgm_composer-ja',
+  title: '作曲者モード (JA)',
+  defaultTotal: 10,
+  locale: 'ja',
+}
+
+const FACETS: Manifest['facets'] = {
+  difficulty: ['easy', 'normal', 'hard', 'mixed'],
+  era: ['80s', '90s', '00s', '10s', '20s', 'mixed'],
+  series: ['ff', 'dq', 'zelda', 'mario', 'sonic', 'pokemon', 'mixed'],
+}
+
+function toBooleanFlag(value?: string): boolean {
+  if (!value) return false
+  const lowered = value.toLowerCase()
+  return lowered === '1' || lowered === 'true' || lowered === 'on' || lowered === 'yes'
+}
+
+export function buildManifest(options: { composerModeEnabled?: boolean } = {}): Manifest {
+  const composerModeEnabled = Boolean(options.composerModeEnabled)
+
+  const modes: Manifest['modes'] = [BASE_MODE]
+  if (composerModeEnabled) {
+    modes.push(COMPOSER_MODE)
+  }
+
+  return {
+    schema_version: 2,
+    modes,
+    facets: FACETS,
+    features: {
+      inlinePlaybackDefault: false,
+      imageProxyEnabled: false,
+      composerModeEnabled,
+    },
+  }
+}
+
+export function getManifest(env?: Pick<Env, 'COMPOSER_MODE_ENABLED'>): Manifest {
+  const composerModeEnabled = toBooleanFlag(env?.COMPOSER_MODE_ENABLED)
+  return buildManifest({ composerModeEnabled })
+}
+
+export function getDefaultMode(manifest: Manifest = buildManifest()): Manifest['modes'][number] {
   return manifest.modes[0]
 }
 
-export function isValidFacetValue(facet: keyof Manifest['facets'], value: string): boolean {
+export function findMode(modeId: string | undefined, manifest: Manifest = buildManifest()) {
+  if (!modeId) {
+    return getDefaultMode(manifest)
+  }
+  return manifest.modes.find((mode) => mode.id === modeId)
+}
+
+export function isValidFacetValue(
+  facet: keyof Manifest['facets'],
+  value: string,
+  manifest: Manifest = buildManifest(),
+): boolean {
   return manifest.facets[facet].includes(value)
 }

--- a/workers/shared/lib/filters.ts
+++ b/workers/shared/lib/filters.ts
@@ -34,13 +34,14 @@ export function createFilterKey(filters?: FilterOptions | null, modeId?: string)
   const normalized = normalizeFilters(filters)
   const payload: Record<string, unknown> = {}
 
-  if (modeId) {
-    payload.mode = modeId
-  }
-
   const sortedKeys = Object.keys(normalized).sort()
+  const allKeys = modeId ? [...sortedKeys, 'mode'].sort() : sortedKeys
 
-  for (const key of sortedKeys) {
+  for (const key of allKeys) {
+    if (key === 'mode') {
+      payload.mode = modeId
+      continue
+    }
     const value = normalized[key as keyof FilterOptions]
     if (Array.isArray(value)) {
       payload[key] = value.slice().sort()

--- a/workers/shared/lib/filters.ts
+++ b/workers/shared/lib/filters.ts
@@ -30,14 +30,15 @@ export function normalizeFilters(filters?: FilterOptions | null): FilterOptions 
   return normalized
 }
 
-export function createFilterKey(filters?: FilterOptions | null): string {
+export function createFilterKey(filters?: FilterOptions | null, modeId?: string): string {
   const normalized = normalizeFilters(filters)
-  if (Object.keys(normalized).length === 0) {
-    return CANONICAL_FILTER_KEY
+  const payload: Record<string, unknown> = {}
+
+  if (modeId) {
+    payload.mode = modeId
   }
 
   const sortedKeys = Object.keys(normalized).sort()
-  const payload: Record<string, unknown> = {}
 
   for (const key of sortedKeys) {
     const value = normalized[key as keyof FilterOptions]
@@ -46,6 +47,10 @@ export function createFilterKey(filters?: FilterOptions | null): string {
     } else if (value !== undefined) {
       payload[key] = value
     }
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return CANONICAL_FILTER_KEY
   }
 
   return JSON.stringify(payload)

--- a/workers/shared/lib/token.ts
+++ b/workers/shared/lib/token.ts
@@ -18,6 +18,7 @@ export interface Phase2TokenPayload {
   iat: number // Issued at (Unix timestamp)
   exp: number // Expiration (Unix timestamp)
   mode?: string // Quiz mode identifier
+  arm?: string // Experiment arm identifier (treatment/control)
   date?: string // Round date in YYYY-MM-DD (JST)
   aud?: string // Audience (optional, e.g., "rounds")
   nbf?: number // Not before (optional)

--- a/workers/shared/types/env.ts
+++ b/workers/shared/types/env.ts
@@ -32,4 +32,8 @@ export interface Env {
   OBS_SLACK_WEBHOOK_URL?: string
   /** Optional service/stack label for observability payloads */
   OBS_SERVICE?: string
+  /** Feature flag: enable composer mode + adaptive gameplay (Phase 4B) */
+  COMPOSER_MODE_ENABLED?: string
+  /** A/B treatment ratio for gameplay experiments (0-100, default 50) */
+  AB_TREATMENT_RATIO?: string
 }

--- a/workers/shared/types/manifest.ts
+++ b/workers/shared/types/manifest.ts
@@ -14,6 +14,7 @@ export interface ManifestFacets {
 export interface ManifestFeatures {
   inlinePlaybackDefault: boolean
   imageProxyEnabled: boolean
+  composerModeEnabled: boolean
 }
 
 export interface Manifest {

--- a/workers/tests/filters.spec.ts
+++ b/workers/tests/filters.spec.ts
@@ -28,7 +28,10 @@ describe('filter utilities', () => {
   })
 
   it('creates stable filter key for complex filters with mode', () => {
-    const key = createFilterKey({ difficulty: 'hard', era: '90s', series: ['zelda', 'ff'] }, 'vgm_v1-ja')
+    const key = createFilterKey(
+      { difficulty: 'hard', era: '90s', series: ['zelda', 'ff'] },
+      'vgm_v1-ja',
+    )
     expect(key).toBe('{"difficulty":"hard","era":"90s","mode":"vgm_v1-ja","series":["ff","zelda"]}')
   })
 

--- a/workers/tests/filters.spec.ts
+++ b/workers/tests/filters.spec.ts
@@ -18,13 +18,18 @@ describe('filter utilities', () => {
     expect(normalizeFilters(filters)).toEqual({ series: ['dq', 'ff', 'zelda'] })
   })
 
-  it('creates canonical key for empty filters', () => {
+  it('creates canonical key for empty filters and no mode', () => {
     expect(createFilterKey(undefined)).toBe(CANONICAL_FILTER_KEY)
   })
 
-  it('creates stable filter key for complex filters', () => {
-    const key = createFilterKey({ difficulty: 'hard', era: '90s', series: ['zelda', 'ff'] })
-    expect(key).toBe('{"difficulty":"hard","era":"90s","series":["ff","zelda"]}')
+  it('includes mode in filter key when provided', () => {
+    const key = createFilterKey(undefined, 'vgm_composer-ja')
+    expect(key).toBe('{"mode":"vgm_composer-ja"}')
+  })
+
+  it('creates stable filter key for complex filters with mode', () => {
+    const key = createFilterKey({ difficulty: 'hard', era: '90s', series: ['zelda', 'ff'] }, 'vgm_v1-ja')
+    expect(key).toBe('{"difficulty":"hard","era":"90s","mode":"vgm_v1-ja","series":["ff","zelda"]}')
   })
 
   it('hashes filter key deterministically', () => {


### PR DESCRIPTION
## Summary
- add composer mode manifest flag, mode-aware rounds, and deterministic A/B arm assignment with env-configurable ratio
- implement composer-only sampling/choices, coverage alerting, difficulty scoring heuristics, and rollback runbook
- extend frontend i18n/UI, metrics (quiz_start/result/revisit with mode/arm), MSW fixtures/handlers, and Playwright coverage

## Testing
- npm run lint
- npm run typecheck
- npm run test:e2e -- --project=chromium
